### PR TITLE
scaffold: assignment/discussion protocol + PR approval policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This repo currently contains the **v1 design docs** and execution plan for:
 - `docs/milestones.md` — Milestones, phases, and delivery checkpoints
 - `docs/task-breakdown.md` — Actionable work packages
 - `docs/contracts/` — Role contracts (including Reviewer Worker)
-- `docs/governance/` — Labels, states, and transition gate definitions
+- `docs/governance/` — Labels, states, transition gates, and PR approval policy
+- `docs/protocols/` — Assignment and discussion protocols
 - `docs/rubrics/complexity.md` — Complexity scoring system
 
 ## Immediate Next Step

--- a/docs/governance/pr-approval-policy.md
+++ b/docs/governance/pr-approval-policy.md
@@ -1,0 +1,38 @@
+# PR Approval Policy (v1)
+
+## Independent Review Rule
+- PR authoring Coding Agent cannot be the sole approver.
+- Reviewer Worker and/or OgaArchitect must review.
+
+## Human Approval Modes
+
+### Mode A: All PRs require human approval
+```yaml
+all_prs_require_human_approval: true
+critical_prs_require_human_approval: false
+```
+
+### Mode B: Critical PRs require human approval only
+```yaml
+all_prs_require_human_approval: false
+critical_prs_require_human_approval: true
+criticality:
+  complexity_threshold: 4
+  labels:
+    - critical-change
+    - security
+    - data-migration
+```
+
+## Merge Gates
+A PR is merge-eligible when:
+1. required tests pass
+2. independent reviewer decision is approval
+3. policy-required human approval exists
+4. linked issue transition criteria are satisfied
+
+## Return Path
+If review fails:
+- PR marked changes-requested
+- issue gets `status:qa-return` or review-return label
+- assigned worker enters reserved fix window until resolution

--- a/docs/protocols/assignment-flow.md
+++ b/docs/protocols/assignment-flow.md
@@ -1,0 +1,52 @@
+# Assignment Flow Protocol (M1/M2)
+
+## Goal
+Ensure OgaArchitect is the assignment authority while workers remain autonomous requesters.
+
+## Flow
+1. Worker posts readiness signal
+2. OgaArchitect evaluates queue + policy + dependencies
+3. OgaArchitect assigns one eligible task
+4. Worker acknowledges assignment
+5. Worker updates task status to in-progress
+6. Worker delivers artifacts and requests transition
+
+## Readiness Signal Format
+Recommended comment/discussion payload:
+
+```text
+READY
+worker: <worker-id>
+role: <role>
+capabilities: <comma-separated>
+capacity: <n>
+project-scope: <keys or all>
+```
+
+## Assignment Response Format
+
+```text
+ASSIGN
+task: <issue-number>
+role: <role>
+due: <target>
+context-pack: <doc links>
+constraints: <must/must-not>
+```
+
+## Guardrails
+- Worker cannot self-assign from backlog directly.
+- OgaArchitect must verify dependency readiness before assignment.
+- C4/C5 tasks cannot be assigned to execution before decomposition completion.
+- QA-return tasks override normal queue order for same worker during fix window.
+
+## Timeout/Abandonment (GitHub-first)
+- If no ACK in `ack_timeout_min`, OgaArchitect unassigns and requeues.
+- If no progress update in `stale_timeout_min`, task marked `status:blocked` + escalation.
+
+## Config Knobs
+- `ack_timeout_min`
+- `stale_timeout_min`
+- `max_tasks_per_worker`
+- `fix_window_min`
+- `max_new_tasks_during_fix_window`

--- a/docs/protocols/discussion-protocol.md
+++ b/docs/protocols/discussion-protocol.md
@@ -1,0 +1,46 @@
+# Discussion Protocol (M1)
+
+> Note: GitHub Discussions must be enabled in repo settings.
+
+## Discussion Channels (by category)
+
+1. **Dispatch**
+   - worker readiness
+   - task requests
+   - assignment acknowledgements
+
+2. **Standup**
+   - periodic health summaries
+   - stuck items
+   - capacity and risk notes
+
+3. **Escalations**
+   - blockers needing human decision
+   - architecture/UI feasibility conflicts
+
+## Message Discipline
+- Use concise structured updates.
+- Link all statements back to issue/PR IDs.
+- Final decisions must be mirrored to issue/PR comments.
+
+## Suggested Message Templates
+
+### Worker Ready
+```text
+[READY] worker=<id> role=<role> capacity=<n> projects=<keys>
+```
+
+### Blocker
+```text
+[BLOCKED] issue=#123 reason=<summary> needs=<decision/input>
+```
+
+### Escalation to Human
+```text
+[ESCALATION] issue=#123 options=A|B recommendation=<choice>
+```
+
+### Decision Mirror
+```text
+[DECISION] issue=#123 outcome=<chosen option> rationale=<1-2 lines>
+```


### PR DESCRIPTION
## Summary
- Add assignment flow protocol (worker request -> OgaArchitect assignment)
- Add discussion protocol for dispatch/standup/escalation
- Add PR approval policy (independent reviewer + human approval modes)
- Update README docs index

## Notes
- This unblocks Milestone 1/2 governance execution
- GitHub Discussions are referenced as optional and require enabling in repo settings

## Request
Please review and approve. After merge, I will scaffold config templates and pilot login-task flow artifacts.