### PR TITLE
feat: add Oga adapter wiring for event/cli/webhook inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Unit tests for Oga guard behavior.
 - `OgaRuntimeService` scaffold for policy-backed assignment/transition decisions.
 - Unit tests for Oga runtime service behavior.
+- Adapter handlers for assignment, transition, and webhook payload inputs.
+- Unit tests for adapter routing and normalized decision outputs.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,3 +50,9 @@ Core references:
 - Exposed assignment and transition evaluation methods.
 - Added tests for service decision paths.
 - Agent: Matrim
+
+### 2026-02-24 — Oga Adapter Wiring (scaffold)
+- Added adapter handlers for assignment, transition, and webhook inputs.
+- Added normalized adapter output contract.
+- Added tests for adapter routing behavior.
+- Agent: Matrim

--- a/packages/oga/CONTEXT.md
+++ b/packages/oga/CONTEXT.md
@@ -17,3 +17,8 @@
 ### 2026-02-24 — Runtime service scaffold (Matrim)
 - Added `OgaRuntimeService` for assignment and transition evaluation.
 - Added service-level tests for decision behavior.
+
+### 2026-02-24 — Adapter routing scaffold (Matrim)
+- Added assignment/transition/webhook adapter handlers.
+- Added normalized adapter output envelopes.
+- Added adapter-level tests for routing + decision behavior.

--- a/packages/oga/readme.md
+++ b/packages/oga/readme.md
@@ -9,4 +9,5 @@ Policy guard utilities and runtime decision service for Oga orchestration.
 ## Entry Points
 - `src/engine.ts`
 - `src/policyGuards.ts`
+- `src/adapters/*`
 - `src/types.ts`

--- a/packages/oga/src/adapters/assignmentAdapter.ts
+++ b/packages/oga/src/adapters/assignmentAdapter.ts
@@ -1,0 +1,23 @@
+import type { OgaRuntimeService } from "../engine.js";
+import type { AdapterDecisionOutput, AssignmentAdapterInput } from "./types.js";
+
+/**
+ * Handle assignment decision inputs from external adapters.
+ *
+ * @param runtime - Oga runtime decision service.
+ * @param input - Assignment envelope from event/cli/webhook source.
+ * @returns Normalized adapter decision output.
+ */
+export function handleAssignmentInput(
+  runtime: OgaRuntimeService,
+  input: AssignmentAdapterInput
+): AdapterDecisionOutput {
+  const result = runtime.evaluateAssignment(input.payload);
+
+  return {
+    requestId: input.requestId,
+    allowed: result.allowed,
+    reason: result.reason,
+    route: "assign"
+  };
+}

--- a/packages/oga/src/adapters/transitionAdapter.ts
+++ b/packages/oga/src/adapters/transitionAdapter.ts
@@ -1,0 +1,23 @@
+import type { OgaRuntimeService } from "../engine.js";
+import type { AdapterDecisionOutput, TransitionAdapterInput } from "./types.js";
+
+/**
+ * Handle transition decision inputs from external adapters.
+ *
+ * @param runtime - Oga runtime decision service.
+ * @param input - Transition envelope from event/cli/webhook source.
+ * @returns Normalized adapter decision output.
+ */
+export function handleTransitionInput(
+  runtime: OgaRuntimeService,
+  input: TransitionAdapterInput
+): AdapterDecisionOutput {
+  const result = runtime.evaluateTransition(input.payload);
+
+  return {
+    requestId: input.requestId,
+    allowed: result.allowed,
+    reason: result.reason,
+    route: "transition"
+  };
+}

--- a/packages/oga/src/adapters/types.ts
+++ b/packages/oga/src/adapters/types.ts
@@ -1,0 +1,29 @@
+import type { AssignmentRequest, TransitionRequest } from "../types.js";
+
+/**
+ * Adapter input envelope for assignment decision requests.
+ */
+export interface AssignmentAdapterInput {
+  requestId: string;
+  source: "event" | "cli" | "webhook";
+  payload: AssignmentRequest;
+}
+
+/**
+ * Adapter input envelope for transition decision requests.
+ */
+export interface TransitionAdapterInput {
+  requestId: string;
+  source: "event" | "cli" | "webhook";
+  payload: TransitionRequest;
+}
+
+/**
+ * Unified adapter output payload.
+ */
+export interface AdapterDecisionOutput {
+  requestId: string;
+  allowed: boolean;
+  reason?: string;
+  route: "assign" | "transition";
+}

--- a/packages/oga/src/adapters/webhookAdapter.ts
+++ b/packages/oga/src/adapters/webhookAdapter.ts
@@ -1,0 +1,39 @@
+import type { OgaRuntimeService } from "../engine.js";
+import { handleAssignmentInput } from "./assignmentAdapter.js";
+import { handleTransitionInput } from "./transitionAdapter.js";
+import type {
+  AdapterDecisionOutput,
+  AssignmentAdapterInput,
+  TransitionAdapterInput
+} from "./types.js";
+
+/**
+ * Handle generic webhook payloads and route to assignment/transition adapters.
+ *
+ * @param runtime - Oga runtime decision service.
+ * @param body - Untrusted webhook payload.
+ * @returns Decision output when payload is valid.
+ * @throws {Error} When payload type is unknown.
+ */
+export function handleWebhookPayload(
+  runtime: OgaRuntimeService,
+  body: { type: "assignment" | "transition"; requestId: string; payload: unknown }
+): AdapterDecisionOutput {
+  if (body.type === "assignment") {
+    return handleAssignmentInput(runtime, {
+      requestId: body.requestId,
+      source: "webhook",
+      payload: body.payload as AssignmentAdapterInput["payload"]
+    });
+  }
+
+  if (body.type === "transition") {
+    return handleTransitionInput(runtime, {
+      requestId: body.requestId,
+      source: "webhook",
+      payload: body.payload as TransitionAdapterInput["payload"]
+    });
+  }
+
+  throw new Error("Unsupported webhook payload type");
+}

--- a/packages/oga/src/index.ts
+++ b/packages/oga/src/index.ts
@@ -15,3 +15,13 @@ export {
 
 export type { AssignmentDecision, TransitionDecision } from "./engine.js";
 export { OgaRuntimeService } from "./engine.js";
+
+export type {
+  AdapterDecisionOutput,
+  AssignmentAdapterInput,
+  TransitionAdapterInput
+} from "./adapters/types.js";
+
+export { handleAssignmentInput } from "./adapters/assignmentAdapter.js";
+export { handleTransitionInput } from "./adapters/transitionAdapter.js";
+export { handleWebhookPayload } from "./adapters/webhookAdapter.js";

--- a/packages/oga/test/adapters.test.ts
+++ b/packages/oga/test/adapters.test.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  handleAssignmentInput,
+  handleTransitionInput,
+  handleWebhookPayload,
+  OgaRuntimeService
+} from "../src/index.js";
+
+const policyPath = path.resolve(process.cwd(), "../../config/policy.example.yaml");
+
+describe("oga adapters", () => {
+  it("test_handleAssignmentInput_returns_normalized_decision", () => {
+    const runtime = new OgaRuntimeService(policyPath);
+    const output = handleAssignmentInput(runtime, {
+      requestId: "req-assign-1",
+      source: "cli",
+      payload: {
+        workerId: "qa-1",
+        workerRole: "qa",
+        taskComplexity: 2,
+        taskBlocked: false,
+        isQaReturn: false,
+        isInFixWindow: false,
+        workerOpenTasks: 0
+      }
+    });
+
+    expect(output.route).toBe("assign");
+    expect(output.allowed).toBe(true);
+  });
+
+  it("test_handleTransitionInput_returns_rejection_reason_when_invalid", () => {
+    const runtime = new OgaRuntimeService(policyPath);
+    const output = handleTransitionInput(runtime, {
+      requestId: "req-trans-1",
+      source: "event",
+      payload: {
+        from: "execution",
+        to: "verification",
+        hasRequiredArtifacts: true,
+        hasIndependentReviewerApproval: false,
+        humanApproved: true,
+        complexity: 3,
+        decomposedForExecution: true
+      }
+    });
+
+    expect(output.route).toBe("transition");
+    expect(output.allowed).toBe(false);
+    expect(output.reason).toMatch(/reviewer/i);
+  });
+
+  it("test_handleWebhookPayload_routes_assignment_payload", () => {
+    const runtime = new OgaRuntimeService(policyPath);
+    const output = handleWebhookPayload(runtime, {
+      type: "assignment",
+      requestId: "req-webhook-1",
+      payload: {
+        workerId: "qa-2",
+        workerRole: "qa",
+        taskComplexity: 1,
+        taskBlocked: false,
+        isQaReturn: false,
+        isInFixWindow: false,
+        workerOpenTasks: 0
+      }
+    });
+
+    expect(output.route).toBe("assign");
+    expect(output.allowed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Task Tracker
- [x] Task 1: Add adapter input/output contracts
- [x] Task 2: Implement assignment and transition adapters
- [x] Task 3: Implement webhook routing adapter
- [x] Task 4: Add adapter tests and run full check
- [x] Task 5: Update context/changelog/docs

## Summary
Adds adapter wiring for event/CLI/webhook style inputs so Oga runtime can process normalized assignment/transition requests via `OgaRuntimeService`.

## Changed Files
- packages/oga/src/adapters/types.ts
- packages/oga/src/adapters/assignmentAdapter.ts
- packages/oga/src/adapters/transitionAdapter.ts
- packages/oga/src/adapters/webhookAdapter.ts
- packages/oga/src/index.ts
- packages/oga/test/adapters.test.ts
- packages/oga/readme.md
- packages/oga/CONTEXT.md
- CONTEXT.md
- CHANGELOG.md

## Verification
- `npm run check` passed
  - build: pass
  - tests: pass (`oga 10/10`, `policy 2/2`)

## Notes
- Adapter layer is side-effect free for now (decision normalization only).
- Next step: bind adapter outputs to real transport handlers and GitHub action executors.
