### PR TITLE
feat: add execution handler dispatcher and runtime bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,6 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Unit tests for Oga runtime service behavior.
 - Adapter handlers for assignment, transition, and webhook payload inputs.
 - Unit tests for adapter routing and normalized decision outputs.
+- Execution handler contracts, dispatcher, and in-memory handler scaffold.
+- Runtime bindings from adapter decisions to execution handlers.
+- Unit tests for execution binding flow.

--- a/packages/oga/CONTEXT.md
+++ b/packages/oga/CONTEXT.md
@@ -22,3 +22,9 @@
 - Added assignment/transition/webhook adapter handlers.
 - Added normalized adapter output envelopes.
 - Added adapter-level tests for routing + decision behavior.
+
+### 2026-02-24 — Execution handler bindings scaffold (Matrim)
+- Added execution action contracts and dispatcher.
+- Added in-memory handlers for side-effect-safe routing.
+- Added runtime binding helpers from adapter inputs to handlers.
+- Added tests for assignment/transition binding flow.

--- a/packages/oga/readme.md
+++ b/packages/oga/readme.md
@@ -10,4 +10,5 @@ Policy guard utilities and runtime decision service for Oga orchestration.
 - `src/engine.ts`
 - `src/policyGuards.ts`
 - `src/adapters/*`
+- `src/execution/*`
 - `src/types.ts`

--- a/packages/oga/src/execution/dispatcher.ts
+++ b/packages/oga/src/execution/dispatcher.ts
@@ -1,0 +1,39 @@
+import type { AdapterDecisionOutput } from "../adapters/types.js";
+import type {
+  AssignmentDecisionHandler,
+  TransitionDecisionHandler
+} from "./types.js";
+import { toExecutionAction } from "./types.js";
+
+/**
+ * Dispatch adapter decision outputs to assignment/transition handlers.
+ */
+export class ExecutionDispatcher {
+  private readonly assignmentHandler: AssignmentDecisionHandler;
+  private readonly transitionHandler: TransitionDecisionHandler;
+
+  /**
+   * Create dispatcher with explicit handler dependencies.
+   */
+  constructor(
+    assignmentHandler: AssignmentDecisionHandler,
+    transitionHandler: TransitionDecisionHandler
+  ) {
+    this.assignmentHandler = assignmentHandler;
+    this.transitionHandler = transitionHandler;
+  }
+
+  /**
+   * Dispatch assignment route decision to assignment handler.
+   */
+  public async dispatchAssignment(decision: AdapterDecisionOutput): Promise<void> {
+    await this.assignmentHandler.handle(toExecutionAction("assignment", decision));
+  }
+
+  /**
+   * Dispatch transition route decision to transition handler.
+   */
+  public async dispatchTransition(decision: AdapterDecisionOutput): Promise<void> {
+    await this.transitionHandler.handle(toExecutionAction("transition", decision));
+  }
+}

--- a/packages/oga/src/execution/inMemoryHandlers.ts
+++ b/packages/oga/src/execution/inMemoryHandlers.ts
@@ -1,0 +1,27 @@
+import type {
+  AssignmentDecisionHandler,
+  ExecutionAction,
+  TransitionDecisionHandler
+} from "./types.js";
+
+/**
+ * In-memory assignment handler for side-effect-safe scaffolding and tests.
+ */
+export class InMemoryAssignmentHandler implements AssignmentDecisionHandler {
+  public readonly actions: ExecutionAction[] = [];
+
+  public async handle(action: ExecutionAction): Promise<void> {
+    this.actions.push(action);
+  }
+}
+
+/**
+ * In-memory transition handler for side-effect-safe scaffolding and tests.
+ */
+export class InMemoryTransitionHandler implements TransitionDecisionHandler {
+  public readonly actions: ExecutionAction[] = [];
+
+  public async handle(action: ExecutionAction): Promise<void> {
+    this.actions.push(action);
+  }
+}

--- a/packages/oga/src/execution/runtimeBindings.ts
+++ b/packages/oga/src/execution/runtimeBindings.ts
@@ -1,0 +1,32 @@
+import type { OgaRuntimeService } from "../engine.js";
+import type {
+  AssignmentAdapterInput,
+  TransitionAdapterInput
+} from "../adapters/types.js";
+import { handleAssignmentInput } from "../adapters/assignmentAdapter.js";
+import { handleTransitionInput } from "../adapters/transitionAdapter.js";
+import { ExecutionDispatcher } from "./dispatcher.js";
+
+/**
+ * Bind assignment adapter input to execution dispatcher.
+ */
+export async function processAssignment(
+  runtime: OgaRuntimeService,
+  dispatcher: ExecutionDispatcher,
+  input: AssignmentAdapterInput
+): Promise<void> {
+  const decision = handleAssignmentInput(runtime, input);
+  await dispatcher.dispatchAssignment(decision);
+}
+
+/**
+ * Bind transition adapter input to execution dispatcher.
+ */
+export async function processTransition(
+  runtime: OgaRuntimeService,
+  dispatcher: ExecutionDispatcher,
+  input: TransitionAdapterInput
+): Promise<void> {
+  const decision = handleTransitionInput(runtime, input);
+  await dispatcher.dispatchTransition(decision);
+}

--- a/packages/oga/src/execution/types.ts
+++ b/packages/oga/src/execution/types.ts
@@ -1,0 +1,44 @@
+import type { AdapterDecisionOutput } from "../adapters/types.js";
+
+/**
+ * Execution action emitted by adapter decision routing.
+ */
+export interface ExecutionAction {
+  kind: "assignment" | "transition";
+  requestId: string;
+  allowed: boolean;
+  reason?: string;
+}
+
+/**
+ * Handler contract for assignment decisions.
+ */
+export interface AssignmentDecisionHandler {
+  handle(action: ExecutionAction): Promise<void>;
+}
+
+/**
+ * Handler contract for transition decisions.
+ */
+export interface TransitionDecisionHandler {
+  handle(action: ExecutionAction): Promise<void>;
+}
+
+/**
+ * Convert adapter decision output into execution action payload.
+ *
+ * @param route - Route kind.
+ * @param decision - Adapter decision output.
+ * @returns Execution action.
+ */
+export function toExecutionAction(
+  route: "assignment" | "transition",
+  decision: AdapterDecisionOutput
+): ExecutionAction {
+  return {
+    kind: route,
+    requestId: decision.requestId,
+    allowed: decision.allowed,
+    reason: decision.reason
+  };
+}

--- a/packages/oga/src/index.ts
+++ b/packages/oga/src/index.ts
@@ -25,3 +25,16 @@ export type {
 export { handleAssignmentInput } from "./adapters/assignmentAdapter.js";
 export { handleTransitionInput } from "./adapters/transitionAdapter.js";
 export { handleWebhookPayload } from "./adapters/webhookAdapter.js";
+
+export type {
+  AssignmentDecisionHandler,
+  ExecutionAction,
+  TransitionDecisionHandler
+} from "./execution/types.js";
+export { toExecutionAction } from "./execution/types.js";
+export { ExecutionDispatcher } from "./execution/dispatcher.js";
+export {
+  InMemoryAssignmentHandler,
+  InMemoryTransitionHandler
+} from "./execution/inMemoryHandlers.js";
+export { processAssignment, processTransition } from "./execution/runtimeBindings.js";

--- a/packages/oga/test/executionBindings.test.ts
+++ b/packages/oga/test/executionBindings.test.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { OgaRuntimeService } from "../src/engine.js";
+import { ExecutionDispatcher } from "../src/execution/dispatcher.js";
+import {
+  InMemoryAssignmentHandler,
+  InMemoryTransitionHandler
+} from "../src/execution/inMemoryHandlers.js";
+import {
+  processAssignment,
+  processTransition
+} from "../src/execution/runtimeBindings.js";
+
+const policyPath = path.resolve(process.cwd(), "../../config/policy.example.yaml");
+
+describe("execution bindings", () => {
+  it("test_processAssignment_writes_action_to_assignment_handler", async () => {
+    const runtime = new OgaRuntimeService(policyPath);
+    const assignmentHandler = new InMemoryAssignmentHandler();
+    const transitionHandler = new InMemoryTransitionHandler();
+    const dispatcher = new ExecutionDispatcher(assignmentHandler, transitionHandler);
+
+    await processAssignment(runtime, dispatcher, {
+      requestId: "req-exec-assign-1",
+      source: "cli",
+      payload: {
+        workerId: "qa-1",
+        workerRole: "qa",
+        taskComplexity: 2,
+        taskBlocked: false,
+        isQaReturn: false,
+        isInFixWindow: false,
+        workerOpenTasks: 0
+      }
+    });
+
+    expect(assignmentHandler.actions).toHaveLength(1);
+    expect(assignmentHandler.actions[0].kind).toBe("assignment");
+    expect(assignmentHandler.actions[0].allowed).toBe(true);
+  });
+
+  it("test_processTransition_writes_action_to_transition_handler", async () => {
+    const runtime = new OgaRuntimeService(policyPath);
+    const assignmentHandler = new InMemoryAssignmentHandler();
+    const transitionHandler = new InMemoryTransitionHandler();
+    const dispatcher = new ExecutionDispatcher(assignmentHandler, transitionHandler);
+
+    await processTransition(runtime, dispatcher, {
+      requestId: "req-exec-transition-1",
+      source: "event",
+      payload: {
+        from: "execution",
+        to: "verification",
+        hasRequiredArtifacts: true,
+        hasIndependentReviewerApproval: false,
+        humanApproved: true,
+        complexity: 3,
+        decomposedForExecution: true
+      }
+    });
+
+    expect(transitionHandler.actions).toHaveLength(1);
+    expect(transitionHandler.actions[0].kind).toBe("transition");
+    expect(transitionHandler.actions[0].allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Task Tracker
- [x] Task 1: Add execution action contracts and handler interfaces
- [x] Task 2: Add dispatcher for assignment/transition decision outputs
- [x] Task 3: Add side-effect-safe in-memory handlers
- [x] Task 4: Add runtime binding helpers from adapters -> dispatcher
- [x] Task 5: Add tests and run full workspace verification

## Summary
Adds execution-layer scaffolding that turns adapter decisions into dispatchable execution actions. This creates the first binding path from Oga adapter decisions to concrete handler contracts.

## Changed Files
- `packages/oga/src/execution/types.ts`
- `packages/oga/src/execution/dispatcher.ts`
- `packages/oga/src/execution/inMemoryHandlers.ts`
- `packages/oga/src/execution/runtimeBindings.ts`
- `packages/oga/src/index.ts`
- `packages/oga/test/executionBindings.test.ts`
- `packages/oga/readme.md`
- `packages/oga/CONTEXT.md`
- `CHANGELOG.md`

## Verification
- `npm run check` ✅
  - build: pass
  - tests: pass (`oga 12/12`, `policy 2/2`)

## Notes
- This remains side-effect-safe (in-memory handlers) by design.
- Next step: implement concrete GitHub execution handlers behind these interfaces.
