### PR TITLE
feat: add GitHub assignment execution handler scaffold + P0 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,5 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Execution handler contracts, dispatcher, and in-memory handler scaffold.
 - Runtime bindings from adapter decisions to execution handlers.
 - Unit tests for execution binding flow.
+- GitHub assignment execution handler scaffold with injected GitHub client boundary.
+- P0 tests for allowed/denied assignment mutation behavior.

--- a/EXECUTION_LOG.md
+++ b/EXECUTION_LOG.md
@@ -3,3 +3,4 @@
 | timestamp (PT) | task | action | result | next step |
 |---|---|---|---|---|
 | 2026-02-24 14:10 | Part 2 GitHub execution handlers | Established explicit execution log artifact for milestone visibility | log initialized | Implement `packages/oga/src/execution/github/githubAssignmentHandler.ts` + P0 test |
+| 2026-02-24 14:25 | Part 2 GitHub execution handlers | Implemented GitHub assignment handler scaffold + P0 tests | local tests green (`oga 14/14`, `policy 2/2`) | Commit and open PR |

--- a/docs/testing/github-execution-handlers-test-matrix.md
+++ b/docs/testing/github-execution-handlers-test-matrix.md
@@ -1,0 +1,77 @@
+# GitHub Execution Handlers — Test Matrix (Assignment + Transition)
+
+Scope: planned GitHub-backed execution handlers that consume `ExecutionAction` from `ExecutionDispatcher` and perform GitHub side effects (Issues/PRs/Projects/comments/labels/status).
+
+Assumptions:
+- Assignment handler applies assignment-side effects (assignee, labels, tracking comment, optional project field).
+- Transition handler applies stage transition side effects (state label/status changes, project column/field updates, transition comment, optional PR status/check).
+- Handlers receive `ExecutionAction` with `{ kind, requestId, allowed, reason }`.
+- Idempotency key is derived from `requestId` (or explicit key).
+
+---
+
+## MVP First (P0)
+
+These should be implemented first to safely ship Part 2.
+
+| Priority | Handler | Test Type | Scenario | Setup / Mock | Expected Assertions |
+|---|---|---|---|---|---|
+| P0 | Assignment | Unit | Allowed assignment applies intended GitHub mutations | Mock GitHub client methods (`addAssignees`, `addLabels`, `createComment`) success | Correct methods called once with expected owner/repo/issue and payload derived from action/context |
+| P0 | Assignment | Unit | Denied assignment is non-mutating but auditable | `allowed=false`, mock `createComment` only | No assignment/label mutations; denial audit comment created with `reason` |
+| P0 | Transition | Unit | Allowed transition applies stage update | Mock label/project/comment methods success | Stage mutation(s) called once; transition comment includes from/to and `requestId` |
+| P0 | Transition | Unit | Denied transition writes denial signal only | `allowed=false` | No stage-changing mutation; denial comment/event recorded |
+| P0 | Assignment | Unit (failure) | GitHub API 500 during mutation is surfaced and contextualized | Make first write fail (`500`) | Handler throws typed error incl. operation name + requestId; partial mutation behavior documented |
+| P0 | Transition | Unit (failure) | GitHub API rate limit/abuse response is retriable-classified | Mock 403 rate-limit headers | Error classification marks retriable; includes retry-after metadata (if present) |
+| P0 | Shared | Unit (idempotency) | Same `requestId` replay does not duplicate side effects | Invoke handler twice with identical action | Second call no-ops (or performs safe read-only check); duplicate comments/labels not created |
+| P0 | Shared | Contract | Handler -> GitHub client call contract remains stable | Contract fixture for action input + expected API calls | Snapshot/contract asserts endpoint names + required params shape |
+
+---
+
+## Important Next (P1)
+
+| Priority | Handler | Test Type | Scenario | Setup / Mock | Expected Assertions |
+|---|---|---|---|---|---|
+| P1 | Assignment | Unit | Existing assignee/label already present | Mock API showing existing state | No duplicate label/assignee calls; still emits deterministic audit trace |
+| P1 | Transition | Unit | Out-of-order transition request rejected safely | Current stage in GitHub mismatches expected `from` | No destructive mutation; explanatory comment or typed conflict error |
+| P1 | Shared | Unit (failure) | Network timeout / ECONNRESET | Transport throws timeout/reset | Error mapped to retriable class; no idempotency key consumption on unknown commit outcome |
+| P1 | Shared | Unit | Permission error (403 insufficient scope) | API returns 403 without rate-limit semantics | Non-retriable classification + operator-friendly remediation message |
+| P1 | Shared | Unit (idempotency) | Same semantic mutation from different duplicate deliveries | Different envelopes, same idempotency key | Exactly-once side effects preserved |
+| P1 | Shared | Contract | Serialization contract for comments/metadata | Golden fixture for comment body templates | Body includes requestId, decision, reason, timestamp format/version tag |
+| P1 | Shared | Contract | Error contract to runtime loop | Simulate retriable/non-retriable errors | Returned/thrown error structure matches runtime expectations (`code`, `retriable`, `context`) |
+
+---
+
+## Hardening / Extended (P2)
+
+| Priority | Handler | Test Type | Scenario | Setup / Mock | Expected Assertions |
+|---|---|---|---|---|---|
+| P2 | Assignment | Unit | Bulk assignment fan-out behavior (if batching enabled) | Multiple actions in sequence | Correct ordering/backpressure; isolated failure does not corrupt others |
+| P2 | Transition | Unit | Multi-artifact transition (issue + PR + project item) partial failure | Fail 2nd of 3 operations | Compensating behavior or clear partial-failure report |
+| P2 | Shared | Contract (integration-lite) | Live schema compatibility with Octokit response fragments | Mock server with realistic payload schema | Parser/mapper tolerates optional/missing fields |
+| P2 | Shared | Property/idempotency | Fuzz duplicate/reordered deliveries | Randomized replay sequences | Final GitHub-visible state converges deterministically |
+
+---
+
+## Suggested Test Layout
+
+- `packages/oga/test/execution/githubAssignmentHandler.test.ts`
+- `packages/oga/test/execution/githubTransitionHandler.test.ts`
+- `packages/oga/test/execution/githubExecutionIdempotency.test.ts`
+- `packages/oga/test/contracts/githubExecutionHandler.contract.test.ts`
+
+Use:
+- **Unit**: Vitest + mocked GitHub client interface (preferred over raw Octokit in handler tests)
+- **Failure simulation**: typed mock errors for 403/404/409/422/429/5xx + network timeouts
+- **Contract**: fixture-driven assertions for outbound call shapes and error envelopes
+
+---
+
+## Minimal MVP Acceptance Gate
+
+Before merge, require all P0 tests green:
+1. Allowed/denied behavior for both handlers
+2. API failure classification for both handlers
+3. Idempotent replay for duplicate requestId
+4. Contract fixture lock for outbound API shape
+
+This gate ensures correctness, safety under retries, and integration stability for Part 2.

--- a/packages/oga/CONTEXT.md
+++ b/packages/oga/CONTEXT.md
@@ -28,3 +28,8 @@
 - Added in-memory handlers for side-effect-safe routing.
 - Added runtime binding helpers from adapter inputs to handlers.
 - Added tests for assignment/transition binding flow.
+
+### 2026-02-24 — GitHub assignment handler scaffold (Matrim)
+- Added `GitHubClient` interface boundary for DI/mocking.
+- Added `GitHubAssignmentHandler` for allowed/denied assignment actions.
+- Added P0 unit tests for mutation and denial-audit behavior.

--- a/packages/oga/src/execution/github/githubAssignmentHandler.ts
+++ b/packages/oga/src/execution/github/githubAssignmentHandler.ts
@@ -1,0 +1,73 @@
+import type { AssignmentDecisionHandler, ExecutionAction } from "../types.js";
+import type { GitHubClient } from "./githubClient.js";
+
+/**
+ * Context required to execute assignment mutations on a GitHub issue.
+ */
+export interface GitHubAssignmentContext {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  assignees: string[];
+  labels: string[];
+}
+
+/**
+ * GitHub-backed assignment decision handler.
+ *
+ * Applies assignment labels/assignees/comments for allowed decisions,
+ * and writes auditable denial comments for denied decisions.
+ */
+export class GitHubAssignmentHandler implements AssignmentDecisionHandler {
+  private readonly client: GitHubClient;
+  private readonly context: GitHubAssignmentContext;
+  private readonly seenRequestIds: Set<string>;
+
+  constructor(client: GitHubClient, context: GitHubAssignmentContext) {
+    this.client = client;
+    this.context = context;
+    this.seenRequestIds = new Set<string>();
+  }
+
+  public async handle(action: ExecutionAction): Promise<void> {
+    if (action.kind !== "assignment") {
+      throw new Error("GitHubAssignmentHandler only supports assignment actions");
+    }
+
+    if (this.seenRequestIds.has(action.requestId)) {
+      return;
+    }
+
+    const issueRef = {
+      owner: this.context.owner,
+      repo: this.context.repo,
+      issueNumber: this.context.issueNumber
+    };
+
+    if (!action.allowed) {
+      await this.client.createComment({
+        ...issueRef,
+        body: `Assignment denied (requestId: ${action.requestId}). Reason: ${action.reason ?? "unknown"}`
+      });
+      this.seenRequestIds.add(action.requestId);
+      return;
+    }
+
+    await this.client.addAssignees({
+      ...issueRef,
+      assignees: this.context.assignees
+    });
+
+    await this.client.addLabels({
+      ...issueRef,
+      labels: this.context.labels
+    });
+
+    await this.client.createComment({
+      ...issueRef,
+      body: `Assignment applied (requestId: ${action.requestId}).`
+    });
+
+    this.seenRequestIds.add(action.requestId);
+  }
+}

--- a/packages/oga/src/execution/github/githubClient.ts
+++ b/packages/oga/src/execution/github/githubClient.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal GitHub client boundary for assignment execution side effects.
+ */
+export interface GitHubClient {
+  addAssignees(params: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    assignees: string[];
+  }): Promise<void>;
+  addLabels(params: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    labels: string[];
+  }): Promise<void>;
+  createComment(params: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    body: string;
+  }): Promise<void>;
+}

--- a/packages/oga/src/index.ts
+++ b/packages/oga/src/index.ts
@@ -38,3 +38,7 @@ export {
   InMemoryTransitionHandler
 } from "./execution/inMemoryHandlers.js";
 export { processAssignment, processTransition } from "./execution/runtimeBindings.js";
+
+export type { GitHubClient } from "./execution/github/githubClient.js";
+export type { GitHubAssignmentContext } from "./execution/github/githubAssignmentHandler.js";
+export { GitHubAssignmentHandler } from "./execution/github/githubAssignmentHandler.js";

--- a/packages/oga/test/execution/githubAssignmentHandler.test.ts
+++ b/packages/oga/test/execution/githubAssignmentHandler.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { GitHubAssignmentHandler } from "../../src/execution/github/githubAssignmentHandler.js";
+import type { GitHubClient } from "../../src/execution/github/githubClient.js";
+
+function createMockClient(): GitHubClient {
+  return {
+    addAssignees: vi.fn(async () => undefined),
+    addLabels: vi.fn(async () => undefined),
+    createComment: vi.fn(async () => undefined)
+  };
+}
+
+describe("GitHubAssignmentHandler", () => {
+  it("test_allowed_assignment_applies_github_mutations", async () => {
+    const client = createMockClient();
+    const handler = new GitHubAssignmentHandler(client, {
+      owner: "Vindi-Van",
+      repo: "harambee",
+      issueNumber: 123,
+      assignees: ["matrim"],
+      labels: ["stage:execution"]
+    });
+
+    await handler.handle({
+      kind: "assignment",
+      requestId: "req-1",
+      allowed: true
+    });
+
+    expect(client.addAssignees).toHaveBeenCalledOnce();
+    expect(client.addLabels).toHaveBeenCalledOnce();
+    expect(client.createComment).toHaveBeenCalledOnce();
+
+    expect(client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueNumber: 123,
+        body: expect.stringContaining("requestId: req-1")
+      })
+    );
+  });
+
+  it("test_denied_assignment_is_non_mutating_but_auditable", async () => {
+    const client = createMockClient();
+    const handler = new GitHubAssignmentHandler(client, {
+      owner: "Vindi-Van",
+      repo: "harambee",
+      issueNumber: 124,
+      assignees: ["matrim"],
+      labels: ["stage:execution"]
+    });
+
+    await handler.handle({
+      kind: "assignment",
+      requestId: "req-2",
+      allowed: false,
+      reason: "policy denied"
+    });
+
+    expect(client.addAssignees).not.toHaveBeenCalled();
+    expect(client.addLabels).not.toHaveBeenCalled();
+    expect(client.createComment).toHaveBeenCalledOnce();
+    expect(client.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining("policy denied")
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Task Tracker
- [x] Task 1: Add GitHub client boundary interface for assignment execution
- [x] Task 2: Implement GitHub assignment handler scaffold (allowed/denied paths)
- [x] Task 3: Add P0 unit tests for mutation vs denial behavior
- [x] Task 4: Integrate exports and update context/changelog/execution log
- [x] Task 5: Run full workspace verification

## Summary
Implements the first concrete GitHub side-effect handler in Part 2: `GitHubAssignmentHandler`.

### Added
- `packages/oga/src/execution/github/githubClient.ts`
- `packages/oga/src/execution/github/githubAssignmentHandler.ts`
- `packages/oga/test/execution/githubAssignmentHandler.test.ts`
- `docs/testing/github-execution-handlers-test-matrix.md`

### Updated
- `packages/oga/src/index.ts` exports
- `packages/oga/CONTEXT.md`
- `CHANGELOG.md`
- `EXECUTION_LOG.md`

## Verification
- `npm run -w @harambee/oga test -- githubAssignmentHandler.test.ts` ✅
- `npm run check` ✅
  - `oga`: 14/14 tests
  - `policy`: 2/2 tests

## Notes
- Handler includes idempotent replay suppression via `requestId` in-memory tracking.
- This is scaffold-level GitHub execution logic behind DI-friendly `GitHubClient`.
- Next step: transition handler + retriable/non-retriable error classification.
