### PR TITLE
docs: codify main-agent onboarding and subagent delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repo currently contains the **v1 design docs** and execution plan for:
 - `docs/task-breakdown.md` — Actionable work packages
 - `docs/contracts/` — Role contracts (including Reviewer Worker)
 - `docs/governance/` — Labels, states, transition gates, PR approval policy, and standards
-- `docs/protocols/` — Assignment and discussion protocols
+- `docs/protocols/` — Assignment, discussion, and agent onboarding protocols
 - `docs/pilots/` — End-to-end pilot execution examples
 - `docs/rubrics/complexity.md` — Complexity scoring system
 - `config/policy.example.yaml` — Configurable workflow/policy controls

--- a/docs/contracts/coding-agent.md
+++ b/docs/contracts/coding-agent.md
@@ -6,6 +6,11 @@ Implement approved task scope with maintainable code quality and test coverage.
 ## Constraint
 Coding Agent cannot self-approve its own PR. Peer review is required by Reviewer Worker and/or OgaArchitect.
 
+Coding Agent is a main role agent. It may spawn subagents for bounded implementation tasks, but remains responsible for:
+- scope compliance
+- artifact quality
+- canonical GitHub updates
+
 ## Responsibilities
 - implement according to accepted UI/architecture inputs
 - write/update tests

--- a/docs/contracts/qa-agent.md
+++ b/docs/contracts/qa-agent.md
@@ -9,6 +9,8 @@ Validate behavior, correctness, and edge-case resilience before release.
 - run scenario and edge-case checks
 - reject with actionable defect bundle when needed
 
+QA Agent is a main role agent. It may spawn subagents for test execution fan-out, but QA Agent remains accountable for final pass/fail decision and evidence roll-up.
+
 ## Required Artifacts
 - verification checklist
 - test result evidence

--- a/docs/protocols/agent-onboarding-template.md
+++ b/docs/protocols/agent-onboarding-template.md
@@ -1,0 +1,54 @@
+# Agent Onboarding Template (Repo-Scoped)
+
+Use this template to onboard non-Oga worker agents safely.
+
+## Required startup contract (all fields required)
+
+```text
+ONBOARD
+agent-id: <name>
+role: <coding-agent|qa-agent|reviewer-worker|devops-agent>
+repo-scope: <owner/repo>
+assignment-source: <issue comments|discussion thread|project queue>
+allowed-actions: <create-branch, commit, open-pr, comment, etc>
+forbidden-actions: <self-assign backlog, merge without approval, cross-repo writes>
+escalation-target: <oga-architect-handle>
+```
+
+## Guardrails
+
+- Worker must reject any assignment without explicit `repo-scope` and `issue` reference.
+- Worker must reject assignments outside configured `repo-scope`.
+- Worker cannot self-assign backlog; assignment authority is OgaArchitect.
+- Worker must post artifact evidence back to GitHub (PR link, logs, test output).
+
+## Assignment payload template
+
+```text
+ASSIGN
+repo: <owner/repo>
+issue: <number>
+role: <role>
+acceptance: <criteria>
+constraints: <must/must-not>
+context-pack: <doc links>
+```
+
+## Worker ACK template
+
+```text
+ACK
+repo: <owner/repo>
+issue: <number>
+role: <role>
+status: accepted
+start-time: <iso8601>
+```
+
+## Reject template (scope mismatch)
+
+```text
+REJECT
+reason: repo-scope mismatch or missing assignment fields
+missing: <repo|issue|role|acceptance>
+```


### PR DESCRIPTION
Codifies operating model requested in chat:
- role agents are main agents
- subagents are optional delegated workers
- only main agents perform canonical GitHub state updates
- single-project default flow for worker readiness/assignment
- repo-scope onboarding template and guardrails