### PR TITLE
test(cli): harden init coverage + clarify init override usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ This repo currently contains the **v1 design docs** and execution plan for:
 - `config/policy.example.yaml` — Configurable workflow/policy controls
 - `CONTEXT.md` / `CHANGELOG.md` — architecture decision log and change history
 
+## CLI Init (Current)
+
+Install and run the CLI:
+
+```bash
+npm install
+npm run build
+node packages/cli/dist/index.js init
+```
+
+Command usage:
+
+```bash
+harambee init [--allow-oga-override]
+```
+
+`--allow-oga-override` bypasses the single-active-Oga guard. Use it **only** with explicit owner approval.
+
 ## Immediate Next Step
 
 Approve v1 docs, then start implementation with:

--- a/docs/protocols/cli-init-v1.md
+++ b/docs/protocols/cli-init-v1.md
@@ -3,6 +3,14 @@
 ## Goal
 Get a new user from install to a working single-project setup in one guided CLI flow.
 
+## Exact Usage
+```bash
+harambee init [--allow-oga-override]
+```
+
+- Default behavior enforces one active Oga per repository.
+- `--allow-oga-override` bypasses that guard and should only be used with explicit owner approval.
+
 ## Scope (v1)
 - one GitHub repo
 - one GitHub Project

--- a/packages/cli/test/ghAuth.test.ts
+++ b/packages/cli/test/ghAuth.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock
+}));
+
+describe("ensureGhAuth", () => {
+  it("throws actionable auth-failure guidance when gh auth is missing", async () => {
+    execFileSyncMock.mockImplementationOnce(() => {
+      throw new Error("not logged in");
+    });
+
+    const { ensureGhAuth } = await import("../src/gh.js");
+
+    expect(() => ensureGhAuth()).toThrow("GitHub auth missing. Run: gh auth login");
+  });
+});

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const answers: string[] = [];
+const ghMocks = {
+  ensureGhAuth: vi.fn(),
+  ensureRepoWriteAccess: vi.fn(),
+  ensureProjectReadable: vi.fn(),
+  getViewerLogin: vi.fn(() => "matrim"),
+  ensureRegistryIssue: vi.fn(() => ({ issueNumber: 42, issueUrl: "https://github.com/acme/repo/issues/42" })),
+  getRegistryIssueBody: vi.fn(() => ""),
+  enforceOgaRolePolicy: vi.fn()
+};
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: () => ({
+    question: vi.fn(async () => answers.shift() ?? ""),
+    close: vi.fn()
+  })
+}));
+
+vi.mock("../src/gh.js", () => ghMocks);
+
+describe("runInit", () => {
+  const originalCwd = process.cwd();
+  let workdir = "";
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    answers.length = 0;
+    workdir = mkdtempSync(join(tmpdir(), "harambee-init-test-"));
+    process.chdir(workdir);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    process.chdir(originalCwd);
+  });
+
+  it("is idempotent and preserves existing config values while merging", async () => {
+    const configDir = join(workdir, ".harambee");
+    const configPath = join(configDir, "config.json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          projectContext: "Existing Context",
+          github: {
+            repoUrl: "https://github.com/existing/repo",
+            projectUrl: "https://github.com/users/existing/projects/7"
+          },
+          agent: {
+            name: "existing-agent",
+            role: "qa"
+          },
+          registry: {
+            issueNumber: 7,
+            issueUrl: "https://github.com/existing/repo/issues/7"
+          }
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    answers.push(
+      "New Context",
+      "https://github.com/new/repo",
+      "https://github.com/users/new/projects/1",
+      "dev"
+    );
+
+    const { runInit } = await import("../src/init.js");
+    await runInit();
+
+    const once = readFileSync(configPath, "utf8");
+    answers.push(
+      "Another Context",
+      "https://github.com/another/repo",
+      "https://github.com/users/another/projects/9",
+      "oga"
+    );
+    await runInit();
+    const twice = readFileSync(configPath, "utf8");
+
+    expect(JSON.parse(twice)).toEqual({
+      version: 1,
+      projectContext: "Existing Context",
+      github: {
+        repoUrl: "https://github.com/existing/repo",
+        projectUrl: "https://github.com/users/existing/projects/7"
+      },
+      agent: {
+        name: "existing-agent",
+        role: "qa"
+      },
+      registry: {
+        issueNumber: 7,
+        issueUrl: "https://github.com/existing/repo/issues/7"
+      }
+    });
+    expect(twice).toBe(once);
+  });
+
+  it("re-prompts with clear messages for invalid repo and project URLs", async () => {
+    answers.push(
+      "Project X",
+      "not-a-repo-url",
+      "https://github.com/acme/repo",
+      "https://github.com/acme/repo",
+      "https://github.com/users/acme/projects/2",
+      "dev"
+    );
+
+    const { runInit } = await import("../src/init.js");
+    await runInit();
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Invalid repo URL. Expected: https://github.com/owner/repo");
+    expect(output).toContain(
+      "Invalid project URL. Expected: https://github.com/users/<owner>/projects/<id> or /orgs/<org>/projects/<id>"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add @harambee/cli init hardening tests for idempotency and config merge behavior
- add invalid repo/project URL re-prompt coverage
- add gh auth failure messaging path test
- document exact init command usage and --allow-oga-override warning

## Validation
- npm run build
- npm run test

## Notes
- override flag should only be used with explicit owner approval
