### PR TITLE
docs: add post-PR56 tracker + M1 dry-run validation checklist

### DIFF
--- a/WORKBOARD.md
+++ b/WORKBOARD.md
@@ -1,16 +1,25 @@
 # WORKBOARD
 
 ## Now (Completed)
-- M1 Workflow Schema & Governance package drafted:
-  - Added issue templates for `task`, `bug`, `design request`, `blocker`
-  - Defined M1 label taxonomy with singleton-family guardrails
-  - Defined GitHub Project v2 column/state model and stage mapping
-  - Codified transition artifact requirements per lifecycle gate
+- PR #56 merged: M1 workflow schema and governance docs/templates are now on `main`.
+- Governance artifacts now present:
+  - Issue templates: `task`, `bug`, `design request`, `blocker`
+  - Label taxonomy with singleton-family rules
+  - Workflow state model and transition gates
+- Runtime harness blocker is resolved in repo context:
+  - Issue #52 is now **closed** (previous blocked item removed)
+
+## Active (In Progress)
+- M1 exit criterion implementation:
+  - Build dry-run validation checklist + evidence plan for one sample issue per template type.
+  - Capture discussion template gap and define closure criteria.
+- Keep milestone/track-level truth in sync in `docs/task-tracker.md`.
 
 ## Next
-- Apply labels/project automation rules in GitHub Project v2 workflow.
-- Validate template usage with one dry-run issue per type.
-- Begin M2 wiring (dispatcher/state automation) after governance sign-off.
+- Execute dry-run on sample issues and collect lifecycle evidence artifacts.
+- Add missing discussion templates (dispatch/standup/escalation) or ratify alternative.
+- Apply/verify GitHub Project v2 automation rules against the documented state model.
+- Start M2 dispatch protocol simulation after M1 exit is evidenced.
 
 ## Blocked
-- Issue #52 remains open pending merge of runtime harness branch/PR evidence.
+- None currently recorded.

--- a/docs/task-tracker.md
+++ b/docs/task-tracker.md
@@ -1,0 +1,55 @@
+# Harambee Task Tracker
+
+_Last updated: 2026-03-02 (post-merge PR #56)_
+
+This tracker records what is **done** vs **not done** by milestone and execution track.
+
+## Snapshot by Milestone
+
+| Milestone | Status | Done | Not Done / Remaining |
+| --- | --- | --- | --- |
+| M0 — Foundation Docs | In review | Architecture/docs baseline exists (`docs/architecture-v1.md`, `docs/milestones.md`, `docs/task-breakdown.md`, `docs/roles-and-contracts.md`, `docs/complexity-rubric.md`) | Explicit "human approval of v1 design baseline" not yet recorded in repo artifacts |
+| M1 — Workflow Schema & Governance | In progress (near exit) | PR #56 merged; governance docs + templates landed (`task`, `bug`, `design request`, `blocker`), state model, labels, transition gate matrix | M1 exit dry-run evidence package (one sample issue per template type) not yet attached as artifact; discussion template gap remains (dispatch/standup/escalation templates absent) |
+| M2 — OgaArchitect Dispatch | Not started | Protocol docs exist (`docs/protocols/assignment-flow.md`) | Simulated assignment run evidence for 3 tasks without collision not yet produced |
+| M3 — Contracts in Practice | Not started | Test matrix seeds exist in docs/testing | End-to-end feature flow with QA bounce-back evidence not yet produced |
+| M4 — Optional Redis Coordination | Not started | None required yet | Failure simulation + safe reassignment evidence not yet produced |
+| M5 — Starter Kit | Not started | None required yet | Reusable template + adoption proof (<1 day) not yet produced |
+
+## Track-Level Status (Done vs Not Done)
+
+### Track A — Governance Schema (M1)
+- ✅ Done
+  - `.github/ISSUE_TEMPLATE/task.yml`
+  - `.github/ISSUE_TEMPLATE/bug.yml`
+  - `.github/ISSUE_TEMPLATE/design-request.yml`
+  - `.github/ISSUE_TEMPLATE/blocker.yml`
+  - `docs/governance/labels.md`
+  - `docs/governance/states.md`
+  - `docs/governance/transition-gates.md`
+- ⏳ Not done
+  - Dry-run validation artifacts confirming real usage per template type.
+
+### Track B — Workflow Operations / Project Wiring
+- ✅ Done
+  - Repo-level governance state/label definitions documented.
+- ⏳ Not done
+  - GitHub Project v2 automation bindings + enforcement evidence not yet captured in repo.
+
+### Track C — Validation & Exit Evidence (M1 Exit)
+- ✅ Done
+  - M1 exit criterion defined in `docs/milestones.md`.
+- ⏳ Not done
+  - Single dry-run package proving one sample issue lifecycle per template type.
+  - Discussion template gap documented and actioned.
+
+### Track D — Runtime/Execution Readiness
+- ✅ Done
+  - Runtime harness evidence path merged (Issue #52 now closed).
+- ⏳ Not done
+  - M2 assignment simulation evidence and anti-collision proof set.
+
+## Source of Truth References
+- PR #56 (merged): <https://github.com/Vindi-Van/harambee/pull/56>
+- Issue #52 (closed): <https://github.com/Vindi-Van/harambee/issues/52>
+- Milestones: `docs/milestones.md`
+- Current board: `WORKBOARD.md`

--- a/docs/validation/m1-dry-run-validation-checklist.md
+++ b/docs/validation/m1-dry-run-validation-checklist.md
@@ -1,0 +1,92 @@
+# M1 Exit Dry-Run Validation Checklist
+
+Purpose: satisfy the M1 exit criterion by defining a dry-run validation for one sample issue per template type, plus explicit handling of the discussion-template gap.
+
+Reference: `docs/milestones.md` → M1 exit criterion: _"dry-run of one sample task through full lifecycle"_.
+
+## Scope
+
+Template types covered in this dry-run package:
+- `task` (`.github/ISSUE_TEMPLATE/task.yml`)
+- `bug` (`.github/ISSUE_TEMPLATE/bug.yml`)
+- `design request` (`.github/ISSUE_TEMPLATE/design-request.yml`)
+- `blocker` (`.github/ISSUE_TEMPLATE/blocker.yml`)
+- (existing non-M1 template) `qa-return` (`.github/ISSUE_TEMPLATE/qa-return.yml`)
+
+Discussion-template gap to validate:
+- `dispatch` discussion template (missing)
+- `standup` discussion template (missing)
+- `escalation` discussion template (missing)
+
+---
+
+## Preflight Checks
+
+- [ ] Labels in `docs/governance/labels.md` are available in repo labels.
+- [ ] Workflow states in `docs/governance/states.md` are mapped in Project v2 (or documented as pending).
+- [ ] Transition gate requirements from `docs/governance/transition-gates.md` are known to reviewer.
+
+---
+
+## Dry-Run Sample Matrix (One Sample per Template Type)
+
+| Template | Sample Issue | Initial Labels Verified | Required Fields Complete | Lifecycle Path (planned) | Evidence Collected | Result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Task | TBD (#____) | [ ] | [ ] | intake → planning → execution → verification → done | [ ] | PASS / FAIL |
+| Bug | TBD (#____) | [ ] | [ ] | intake → planning → execution → verification → done | [ ] | PASS / FAIL |
+| Design Request | TBD (#____) | [ ] | [ ] | design/review → planning → execution or closure | [ ] | PASS / FAIL |
+| Blocker | TBD (#____) | [ ] | [ ] | blocked raised → unblock decision/action → resumed state | [ ] | PASS / FAIL |
+| QA Return (gap-support) | TBD (#____) | [ ] | [ ] | verification failure → execution re-entry → verification pass | [ ] | PASS / FAIL |
+
+Minimum evidence per sample:
+- Issue link and final state
+- Label/state transitions captured (timeline or screenshots)
+- Artifact links as required by gate (PR/test/report/checklist)
+- Closure note summarizing whether template guided execution correctly
+
+---
+
+## Per-Sample Checklist
+
+Use for each sample issue above.
+
+- [ ] Template default labels applied correctly on issue creation.
+- [ ] Required fields were sufficient and not ambiguous.
+- [ ] Stage/status labels updated without singleton-family conflicts.
+- [ ] Gate artifacts attached before advancing states.
+- [ ] Verification step recorded explicit pass/fail.
+- [ ] If failed, return path (QA return / blocker) worked and was documented.
+- [ ] Final state + closure reason captured.
+
+---
+
+## Discussion Template Gap Validation
+
+Current repo status: no `.github/DISCUSSION_TEMPLATE/*` files found.
+
+### Gap Checklist
+- [ ] Confirm desired categories and usage intent:
+  - [ ] dispatch
+  - [ ] standup
+  - [ ] escalation
+- [ ] Define minimum required fields for each discussion template.
+- [ ] Add template files under `.github/DISCUSSION_TEMPLATE/` (or explicitly defer with rationale).
+- [ ] Validate one sample discussion post per template or approved substitute process.
+- [ ] Record pass/fail and follow-up actions.
+
+### Exit Decision Rule for Gap
+M1 validation can be marked complete only when one of the following is true:
+1. Discussion templates are added and sample-post validated, **or**
+2. Maintainers explicitly decide discussion templates are out of scope for M1 and document replacement workflow in `docs/protocols/`.
+
+---
+
+## Completion Summary (to fill after execution)
+
+- Dry-run date:
+- Validator(s):
+- Samples executed:
+- Pass count:
+- Fail count:
+- Open follow-ups:
+- Recommendation: M1 exit **GO / NO-GO**


### PR DESCRIPTION
## Summary
- add `docs/task-tracker.md` with done vs not-done status across milestones/tracks
- update `WORKBOARD.md` to reflect post-PR #56 truth and remove stale blocker (#52 now closed)
- add `docs/validation/m1-dry-run-validation-checklist.md` to implement M1 exit-criterion dry-run plan

## Why
PR #56 merged governance artifacts, but board/tracker and explicit dry-run checklist were still missing. This PR creates a concrete source of truth and exit checklist before M2 begins.

## Validation
- docs-only changes
- verified repo state references:
  - PR #56 merged
  - Issue #52 closed