### PR TITLE
M1 exit dry-run: real lifecycle evidence + discussion template path

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/config.yml
+++ b/.github/DISCUSSION_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Harambee Workflow Governance
+    url: https://github.com/Vindi-Van/harambee/blob/main/docs/governance/transition-gates.md
+    about: Review required stage transitions and artifact gates before posting.

--- a/.github/DISCUSSION_TEMPLATE/dispatch.yml
+++ b/.github/DISCUSSION_TEMPLATE/dispatch.yml
@@ -1,0 +1,29 @@
+title: "[Dispatch] "
+labels: ["stage:intake", "status:ready"]
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What is the assignment outcome?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and constraints
+      description: Boundaries and non-goals.
+    validations:
+      required: true
+  - type: textarea
+    id: owner
+    attributes:
+      label: Owner and role
+      description: Who is executing and what role label applies?
+    validations:
+      required: true
+  - type: textarea
+    id: due
+    attributes:
+      label: Target window
+      description: Expected start/end or SLA.

--- a/.github/DISCUSSION_TEMPLATE/escalation.yml
+++ b/.github/DISCUSSION_TEMPLATE/escalation.yml
@@ -1,0 +1,29 @@
+title: "[Escalation] "
+labels: ["status:blocked", "priority:p0"]
+body:
+  - type: textarea
+    id: blocked_item
+    attributes:
+      label: Blocked item
+      description: Link issue/PR/task currently blocked.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Delivery impact
+      description: What slips if unresolved?
+    validations:
+      required: true
+  - type: textarea
+    id: ask
+    attributes:
+      label: Decision/action needed
+      description: Specific unblock request and owner.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs/screenshots/notes with timestamps.

--- a/.github/DISCUSSION_TEMPLATE/standup.yml
+++ b/.github/DISCUSSION_TEMPLATE/standup.yml
@@ -1,0 +1,22 @@
+title: "[Standup] "
+labels: ["status:in-progress"]
+body:
+  - type: textarea
+    id: yesterday
+    attributes:
+      label: Completed since last update
+    validations:
+      required: true
+  - type: textarea
+    id: today
+    attributes:
+      label: Next planned actions
+    validations:
+      required: true
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Blockers or risks
+      description: Include issue links and unblock asks.
+    validations:
+      required: true

--- a/WORKBOARD.md
+++ b/WORKBOARD.md
@@ -1,25 +1,33 @@
 # WORKBOARD
 
 ## Now (Completed)
-- PR #56 merged: M1 workflow schema and governance docs/templates are now on `main`.
-- Governance artifacts now present:
-  - Issue templates: `task`, `bug`, `design request`, `blocker`
-  - Label taxonomy with singleton-family rules
-  - Workflow state model and transition gates
-- Runtime harness blocker is resolved in repo context:
-  - Issue #52 is now **closed** (previous blocked item removed)
+- Executed M1 real dry-run lifecycle samples for each required issue template:
+  - Task: #58
+  - Bug: #59
+  - Design request: #60
+  - Blocker: #61
+- All four dry-run issues were progressed through lifecycle labels and closed with evidence notes.
+- Updated validation artifact:
+  - `docs/validation/m1-dry-run-validation-checklist.md`
+- Added discussion-template package:
+  - `.github/DISCUSSION_TEMPLATE/config.yml`
+  - `.github/DISCUSSION_TEMPLATE/dispatch.yml`
+  - `.github/DISCUSSION_TEMPLATE/standup.yml`
+  - `.github/DISCUSSION_TEMPLATE/escalation.yml`
+- Added discussion usage/fallback protocol:
+  - `docs/protocols/discussion-template-usage.md`
+- Synced tracker state in `docs/task-tracker.md`.
 
 ## Active (In Progress)
-- M1 exit criterion implementation:
-  - Build dry-run validation checklist + evidence plan for one sample issue per template type.
-  - Capture discussion template gap and define closure criteria.
-- Keep milestone/track-level truth in sync in `docs/task-tracker.md`.
+- M1 closeout decision is now **conditional**:
+  - Issue-template dry-run criterion is satisfied.
+  - Discussion live-post validation is blocked because GitHub Discussions is disabled in repo settings (`has_discussions=false`).
 
 ## Next
-- Execute dry-run on sample issues and collect lifecycle evidence artifacts.
-- Add missing discussion templates (dispatch/standup/escalation) or ratify alternative.
-- Apply/verify GitHub Project v2 automation rules against the documented state model.
-- Start M2 dispatch protocol simulation after M1 exit is evidenced.
+- Maintainer action: enable GitHub Discussions and create/verify categories.
+- Run one live sample discussion post per template (dispatch/standup/escalation).
+- Capture those links in `docs/validation/m1-dry-run-validation-checklist.md` to finalize M1 close.
+- Begin M2 dispatch protocol simulation.
 
 ## Blocked
-- None currently recorded.
+- Live discussion-template validation is blocked pending repo Discussions enablement.

--- a/docs/protocols/discussion-template-usage.md
+++ b/docs/protocols/discussion-template-usage.md
@@ -1,0 +1,31 @@
+# Discussion Template Usage Path (M1)
+
+This protocol defines how Harambee uses GitHub Discussion templates for coordination.
+
+## Templates
+- `dispatch.yml` → assignment kickoff / intent routing
+- `standup.yml` → status cadence updates
+- `escalation.yml` → blocked/risk escalation requiring decision
+
+Location: `.github/DISCUSSION_TEMPLATE/`
+
+## Intended Live Path
+1. Open **Discussions** in repo.
+2. Choose the matching template (dispatch/standup/escalation).
+3. Fill required fields and post.
+4. Link resulting discussion URL in corresponding issue/PR timeline.
+5. Ensure stage/status labels stay aligned with issue state.
+
+## Current Limitation
+As of 2026-03-02, repository API reports `has_discussions=false`.
+
+## Interim Fallback (until Discussions is enabled)
+- Use issue comments with headings matching the template fields.
+- Prefix comments with `[Dispatch]`, `[Standup]`, or `[Escalation]`.
+- Link fallback comments in the M1 validation checklist.
+
+## Exit Completion Requirement
+To fully close discussion-template validation, maintainers must:
+1. Enable Discussions,
+2. Create/verify category mapping,
+3. Post at least one sample discussion per template type.

--- a/docs/task-tracker.md
+++ b/docs/task-tracker.md
@@ -1,6 +1,6 @@
 # Harambee Task Tracker
 
-_Last updated: 2026-03-02 (post-merge PR #56)_
+_Last updated: 2026-03-02 (M1 dry-run execution run)_
 
 This tracker records what is **done** vs **not done** by milestone and execution track.
 
@@ -9,7 +9,7 @@ This tracker records what is **done** vs **not done** by milestone and execution
 | Milestone | Status | Done | Not Done / Remaining |
 | --- | --- | --- | --- |
 | M0 — Foundation Docs | In review | Architecture/docs baseline exists (`docs/architecture-v1.md`, `docs/milestones.md`, `docs/task-breakdown.md`, `docs/roles-and-contracts.md`, `docs/complexity-rubric.md`) | Explicit "human approval of v1 design baseline" not yet recorded in repo artifacts |
-| M1 — Workflow Schema & Governance | In progress (near exit) | PR #56 merged; governance docs + templates landed (`task`, `bug`, `design request`, `blocker`), state model, labels, transition gate matrix | M1 exit dry-run evidence package (one sample issue per template type) not yet attached as artifact; discussion template gap remains (dispatch/standup/escalation templates absent) |
+| M1 — Workflow Schema & Governance | Conditional GO (exit package executed) | Real dry-run executed: one sample issue each for task/bug/design/blocker (#58-#61), lifecycle transitions captured, validation checklist updated, discussion templates + usage protocol added | Final M1 closeout decision pending: repo Discussions currently disabled (`has_discussions=false`), so live discussion-post validation remains |
 | M2 — OgaArchitect Dispatch | Not started | Protocol docs exist (`docs/protocols/assignment-flow.md`) | Simulated assignment run evidence for 3 tasks without collision not yet produced |
 | M3 — Contracts in Practice | Not started | Test matrix seeds exist in docs/testing | End-to-end feature flow with QA bounce-back evidence not yet produced |
 | M4 — Optional Redis Coordination | Not started | None required yet | Failure simulation + safe reassignment evidence not yet produced |
@@ -26,8 +26,9 @@ This tracker records what is **done** vs **not done** by milestone and execution
   - `docs/governance/labels.md`
   - `docs/governance/states.md`
   - `docs/governance/transition-gates.md`
+  - Governance labels provisioned in repo for dry-run execution
 - ⏳ Not done
-  - Dry-run validation artifacts confirming real usage per template type.
+  - None blocking within issue-template scope
 
 ### Track B — Workflow Operations / Project Wiring
 - ✅ Done
@@ -38,18 +39,21 @@ This tracker records what is **done** vs **not done** by milestone and execution
 ### Track C — Validation & Exit Evidence (M1 Exit)
 - ✅ Done
   - M1 exit criterion defined in `docs/milestones.md`.
+  - Dry-run evidence package completed in `docs/validation/m1-dry-run-validation-checklist.md` with real issue links (#58-#61).
+  - Discussion template files added: `.github/DISCUSSION_TEMPLATE/{dispatch,standup,escalation,config}.yml`.
+  - Usage/fallback protocol added: `docs/protocols/discussion-template-usage.md`.
 - ⏳ Not done
-  - Single dry-run package proving one sample issue lifecycle per template type.
-  - Discussion template gap documented and actioned.
+  - Live discussion-post validation blocked until GitHub Discussions is enabled.
 
 ### Track D — Runtime/Execution Readiness
 - ✅ Done
-  - Runtime harness evidence path merged (Issue #52 now closed).
+  - Runtime harness evidence path merged (Issue #52 closed).
 - ⏳ Not done
   - M2 assignment simulation evidence and anti-collision proof set.
 
 ## Source of Truth References
-- PR #56 (merged): <https://github.com/Vindi-Van/harambee/pull/56>
-- Issue #52 (closed): <https://github.com/Vindi-Van/harambee/issues/52>
+- M1 dry-run issues: <https://github.com/Vindi-Van/harambee/issues/58>, <https://github.com/Vindi-Van/harambee/issues/59>, <https://github.com/Vindi-Van/harambee/issues/60>, <https://github.com/Vindi-Van/harambee/issues/61>
+- Validation checklist: `docs/validation/m1-dry-run-validation-checklist.md`
+- Discussion usage protocol: `docs/protocols/discussion-template-usage.md`
 - Milestones: `docs/milestones.md`
 - Current board: `WORKBOARD.md`

--- a/docs/validation/m1-dry-run-validation-checklist.md
+++ b/docs/validation/m1-dry-run-validation-checklist.md
@@ -1,92 +1,84 @@
 # M1 Exit Dry-Run Validation Checklist
 
-Purpose: satisfy the M1 exit criterion by defining a dry-run validation for one sample issue per template type, plus explicit handling of the discussion-template gap.
+Purpose: satisfy the M1 exit criterion by executing one real dry-run issue per required template type and recording objective evidence.
 
 Reference: `docs/milestones.md` → M1 exit criterion: _"dry-run of one sample task through full lifecycle"_.
 
-## Scope
+## Scope Executed (2026-03-02)
 
-Template types covered in this dry-run package:
-- `task` (`.github/ISSUE_TEMPLATE/task.yml`)
-- `bug` (`.github/ISSUE_TEMPLATE/bug.yml`)
-- `design request` (`.github/ISSUE_TEMPLATE/design-request.yml`)
-- `blocker` (`.github/ISSUE_TEMPLATE/blocker.yml`)
-- (existing non-M1 template) `qa-return` (`.github/ISSUE_TEMPLATE/qa-return.yml`)
+Template types executed in this run:
+- `task` (`.github/ISSUE_TEMPLATE/task.yml`) → Issue #58
+- `bug` (`.github/ISSUE_TEMPLATE/bug.yml`) → Issue #59
+- `design request` (`.github/ISSUE_TEMPLATE/design-request.yml`) → Issue #60
+- `blocker` (`.github/ISSUE_TEMPLATE/blocker.yml`) → Issue #61
 
-Discussion-template gap to validate:
-- `dispatch` discussion template (missing)
-- `standup` discussion template (missing)
-- `escalation` discussion template (missing)
+Discussion-template path addressed in this run:
+- Added `.github/DISCUSSION_TEMPLATE/dispatch.yml`
+- Added `.github/DISCUSSION_TEMPLATE/standup.yml`
+- Added `.github/DISCUSSION_TEMPLATE/escalation.yml`
+- Added `.github/DISCUSSION_TEMPLATE/config.yml`
+- Added usage protocol: `docs/protocols/discussion-template-usage.md`
 
 ---
 
 ## Preflight Checks
 
-- [ ] Labels in `docs/governance/labels.md` are available in repo labels.
-- [ ] Workflow states in `docs/governance/states.md` are mapped in Project v2 (or documented as pending).
-- [ ] Transition gate requirements from `docs/governance/transition-gates.md` are known to reviewer.
+- [x] Labels in `docs/governance/labels.md` are now available in repo labels.
+  - Evidence: labels created via `gh label create` set (all governance families present).
+- [ ] Workflow states in Project v2 are mapped (still pending; out of this run’s scope).
+- [x] Transition gate requirements from `docs/governance/transition-gates.md` were used as dry-run gate reference.
 
 ---
 
-## Dry-Run Sample Matrix (One Sample per Template Type)
+## Dry-Run Sample Matrix (One Sample per Required Template)
 
-| Template | Sample Issue | Initial Labels Verified | Required Fields Complete | Lifecycle Path (planned) | Evidence Collected | Result |
+| Template | Sample Issue | Initial Labels Verified | Required Fields Complete | Lifecycle Path Executed | Evidence Collected | Result |
 | --- | --- | --- | --- | --- | --- | --- |
-| Task | TBD (#____) | [ ] | [ ] | intake → planning → execution → verification → done | [ ] | PASS / FAIL |
-| Bug | TBD (#____) | [ ] | [ ] | intake → planning → execution → verification → done | [ ] | PASS / FAIL |
-| Design Request | TBD (#____) | [ ] | [ ] | design/review → planning → execution or closure | [ ] | PASS / FAIL |
-| Blocker | TBD (#____) | [ ] | [ ] | blocked raised → unblock decision/action → resumed state | [ ] | PASS / FAIL |
-| QA Return (gap-support) | TBD (#____) | [ ] | [ ] | verification failure → execution re-entry → verification pass | [ ] | PASS / FAIL |
+| Task | [#58](https://github.com/Vindi-Van/harambee/issues/58) | ✅ (`stage:intake`, `status:ready`, `type:task`, `priority:p2`) | ✅ | intake → execution → verification → done/closed | Issue timeline + comments + close note | PASS |
+| Bug | [#59](https://github.com/Vindi-Van/harambee/issues/59) | ✅ (`stage:intake`, `status:ready`, `type:bug`, `priority:p1`) | ✅ | intake → execution → verification → done/closed | Issue timeline + close note | PASS |
+| Design Request | [#60](https://github.com/Vindi-Van/harambee/issues/60) | ✅ (`stage:design`, `status:ready`, `type:design`, `priority:p2`) | ✅ | design → review-gate → execution → verification → done/closed | Issue timeline + close note | PASS |
+| Blocker | [#61](https://github.com/Vindi-Van/harambee/issues/61) | ✅ (`status:blocked`, `type:blocker`, `priority:p0`) | ✅ | blocked raised → unblock decision → execution → verification → done/closed | Issue timeline + unblock comment + close note | PASS |
 
-Minimum evidence per sample:
-- Issue link and final state
-- Label/state transitions captured (timeline or screenshots)
-- Artifact links as required by gate (PR/test/report/checklist)
-- Closure note summarizing whether template guided execution correctly
+Notes:
+- GitHub CLI form parity limitation: issue forms were represented with equivalent required sections in body text; labels/states were validated through explicit transitions in issue timelines.
+- Stage naming follows current M1 state labels (`stage:*`) as documented in governance.
 
 ---
 
-## Per-Sample Checklist
+## Discussion Template Usage Path Validation
 
-Use for each sample issue above.
-
-- [ ] Template default labels applied correctly on issue creation.
-- [ ] Required fields were sufficient and not ambiguous.
-- [ ] Stage/status labels updated without singleton-family conflicts.
-- [ ] Gate artifacts attached before advancing states.
-- [ ] Verification step recorded explicit pass/fail.
-- [ ] If failed, return path (QA return / blocker) worked and was documented.
-- [ ] Final state + closure reason captured.
-
----
-
-## Discussion Template Gap Validation
-
-Current repo status: no `.github/DISCUSSION_TEMPLATE/*` files found.
+Current repo/API status observed during run:
+- `has_discussions=false` for repo (`gh api repos/Vindi-Van/harambee`)
 
 ### Gap Checklist
-- [ ] Confirm desired categories and usage intent:
-  - [ ] dispatch
-  - [ ] standup
-  - [ ] escalation
-- [ ] Define minimum required fields for each discussion template.
-- [ ] Add template files under `.github/DISCUSSION_TEMPLATE/` (or explicitly defer with rationale).
-- [ ] Validate one sample discussion post per template or approved substitute process.
-- [ ] Record pass/fail and follow-up actions.
+- [x] Confirm desired categories and usage intent represented:
+  - [x] dispatch
+  - [x] standup
+  - [x] escalation
+- [x] Define minimum required fields for each discussion template.
+- [x] Add template files under `.github/DISCUSSION_TEMPLATE/`.
+- [ ] Validate one sample discussion post per template (blocked by Discussions disabled).
+- [x] Record pass/fail and follow-up action.
 
-### Exit Decision Rule for Gap
-M1 validation can be marked complete only when one of the following is true:
-1. Discussion templates are added and sample-post validated, **or**
-2. Maintainers explicitly decide discussion templates are out of scope for M1 and document replacement workflow in `docs/protocols/`.
+Follow-up action required:
+1. Enable GitHub Discussions in repository settings.
+2. Create/verify category mapping and post one sample discussion per template.
+
+Interim replacement workflow (documented):
+- Use issue/discussion fallback protocol in `docs/protocols/discussion-template-usage.md` until Discussions is enabled.
 
 ---
 
-## Completion Summary (to fill after execution)
+## Completion Summary
 
-- Dry-run date:
-- Validator(s):
-- Samples executed:
-- Pass count:
-- Fail count:
+- Dry-run date: 2026-03-02
+- Validator: @matrim-mastermind
+- Samples executed: 4/4 required issue templates
+- Pass count: 4
+- Fail count: 0 (issue templates); 1 pending validation item (discussion live-post verification)
 - Open follow-ups:
-- Recommendation: M1 exit **GO / NO-GO**
+  - Enable and wire GitHub Discussions categories to complete live discussion-post validation.
+  - Map workflow states into Project v2 automation.
+- Recommendation: M1 exit **CONDITIONAL GO**
+  - GO for issue-template lifecycle criterion.
+  - Final closeout depends on discussion enablement decision/validation per documented path.


### PR DESCRIPTION
## Summary
- executed real dry-run issues for all required M1 issue templates: #58 (task), #59 (bug), #60 (design), #61 (blocker)
- progressed each through lifecycle label transitions and closed with evidence comments
- updated `docs/validation/m1-dry-run-validation-checklist.md` with PASS/FAIL matrix and artifact links
- added discussion template package at `.github/DISCUSSION_TEMPLATE/` and usage protocol `docs/protocols/discussion-template-usage.md`
- synced `docs/task-tracker.md` and `WORKBOARD.md` to reflect completion + remaining dependency

## Evidence
- Validation checklist: `docs/validation/m1-dry-run-validation-checklist.md`
- Dry-run issues: #58, #59, #60, #61
- Discussion API status during run: `has_discussions=false` (live discussion-post validation blocked until enabled)

## Exit recommendation
- **Conditional GO** for M1:
  - GO for required issue-template lifecycle criterion
  - pending final discussion live-post validation after Discussions is enabled