### PR TITLE
M1: finalize live discussion validation + closeout docs

### DIFF
--- a/WORKBOARD.md
+++ b/WORKBOARD.md
@@ -17,18 +17,19 @@
 - Added discussion usage/fallback protocol:
   - `docs/protocols/discussion-template-usage.md`
 - Synced tracker state in `docs/task-tracker.md`.
+- Posted live discussion validation samples:
+  - Dispatch: <https://github.com/Vindi-Van/harambee/discussions/64>
+  - Standup: <https://github.com/Vindi-Van/harambee/discussions/65>
+  - Escalation: <https://github.com/Vindi-Van/harambee/discussions/66>
+- Marked M1 discussion validation complete in `docs/validation/m1-dry-run-validation-checklist.md`.
+- Closed M1 tracker status in `docs/task-tracker.md`.
 
 ## Active (In Progress)
-- M1 closeout is **ready to finalize**:
-  - Issue-template dry-run criterion is satisfied.
-  - Repo Discussions setting is enabled (`has_discussions=true`, GraphQL `hasDiscussionsEnabled=true`).
-  - Remaining action: post one sample discussion per template and link evidence.
+- M2 dispatch protocol simulation planning (next milestone).
 
 ## Next
-- Create/verify category mapping for dispatch/standup/escalation discussions.
-- Run one live sample discussion post per template (dispatch/standup/escalation).
-- Capture those links in `docs/validation/m1-dry-run-validation-checklist.md` to finalize M1 close.
-- Begin M2 dispatch protocol simulation.
+- Execute M2 dispatch protocol simulation with 3-task anti-collision evidence set.
+- Wire/verify Project v2 workflow automation mappings for documented governance states.
 
 ## Blocked
 - None.

--- a/docs/task-tracker.md
+++ b/docs/task-tracker.md
@@ -1,6 +1,6 @@
 # Harambee Task Tracker
 
-_Last updated: 2026-03-02 (M1 dry-run execution run)_
+_Last updated: 2026-03-02 (M1 closeout validated)_
 
 This tracker records what is **done** vs **not done** by milestone and execution track.
 
@@ -9,7 +9,7 @@ This tracker records what is **done** vs **not done** by milestone and execution
 | Milestone | Status | Done | Not Done / Remaining |
 | --- | --- | --- | --- |
 | M0 — Foundation Docs | In review | Architecture/docs baseline exists (`docs/architecture-v1.md`, `docs/milestones.md`, `docs/task-breakdown.md`, `docs/roles-and-contracts.md`, `docs/complexity-rubric.md`) | Explicit "human approval of v1 design baseline" not yet recorded in repo artifacts |
-| M1 — Workflow Schema & Governance | In final validation | Real dry-run executed: one sample issue each for task/bug/design/blocker (#58-#61), lifecycle transitions captured, validation checklist updated, discussion templates + usage protocol added, repo Discussions enabled (`has_discussions=true`, GraphQL `hasDiscussionsEnabled=true`) | Post one live sample discussion per template (dispatch/standup/escalation) and record links for final M1 closeout |
+| M1 — Workflow Schema & Governance | Complete | Real dry-run executed: one sample issue each for task/bug/design/blocker (#58-#61), lifecycle transitions captured, validation checklist updated, discussion templates + usage protocol added, repo Discussions enabled (`has_discussions=true`, GraphQL `hasDiscussionsEnabled=true`), and live sample discussions posted for dispatch/standup/escalation (#64-#66) | Optional hardening: dedicated discussion categories; remaining required work is Project v2 automation mapping |
 | M2 — OgaArchitect Dispatch | Not started | Protocol docs exist (`docs/protocols/assignment-flow.md`) | Simulated assignment run evidence for 3 tasks without collision not yet produced |
 | M3 — Contracts in Practice | Not started | Test matrix seeds exist in docs/testing | End-to-end feature flow with QA bounce-back evidence not yet produced |
 | M4 — Optional Redis Coordination | Not started | None required yet | Failure simulation + safe reassignment evidence not yet produced |
@@ -43,7 +43,7 @@ This tracker records what is **done** vs **not done** by milestone and execution
   - Discussion template files added: `.github/DISCUSSION_TEMPLATE/{dispatch,standup,escalation,config}.yml`.
   - Usage/fallback protocol added: `docs/protocols/discussion-template-usage.md`.
 - ⏳ Not done
-  - Live discussion-post validation samples still need to be posted and linked (repo Discussions prerequisite is now satisfied).
+  - Optional hardening: create dedicated discussion categories for dispatch/standup/escalation (current M1 mapping uses default categories).
 
 ### Track D — Runtime/Execution Readiness
 - ✅ Done
@@ -53,6 +53,7 @@ This tracker records what is **done** vs **not done** by milestone and execution
 
 ## Source of Truth References
 - M1 dry-run issues: <https://github.com/Vindi-Van/harambee/issues/58>, <https://github.com/Vindi-Van/harambee/issues/59>, <https://github.com/Vindi-Van/harambee/issues/60>, <https://github.com/Vindi-Van/harambee/issues/61>
+- M1 live discussion samples: <https://github.com/Vindi-Van/harambee/discussions/64>, <https://github.com/Vindi-Van/harambee/discussions/65>, <https://github.com/Vindi-Van/harambee/discussions/66>
 - Validation checklist: `docs/validation/m1-dry-run-validation-checklist.md`
 - Discussion usage protocol: `docs/protocols/discussion-template-usage.md`
 - Milestones: `docs/milestones.md`

--- a/docs/validation/m1-dry-run-validation-checklist.md
+++ b/docs/validation/m1-dry-run-validation-checklist.md
@@ -58,12 +58,23 @@ Current repo/API status observed during run:
   - [x] escalation
 - [x] Define minimum required fields for each discussion template.
 - [x] Add template files under `.github/DISCUSSION_TEMPLATE/`.
-- [ ] Validate one sample discussion post per template (repository setting prerequisite satisfied; sample-post evidence still pending).
+- [x] Validate one sample discussion post per template and record links.
 - [x] Record pass/fail and follow-up action.
 
+Live sample discussion evidence:
+- Dispatch: <https://github.com/Vindi-Van/harambee/discussions/64> (category: General)
+- Standup: <https://github.com/Vindi-Van/harambee/discussions/65> (category: Show and tell)
+- Escalation: <https://github.com/Vindi-Van/harambee/discussions/66> (category: Q&A)
+
+Category mapping used for M1 validation:
+- dispatch → General
+- standup → Show and tell
+- escalation → Q&A
+
+
 Follow-up action required:
-1. Create/verify category mapping.
-2. Post one sample discussion per template and record links.
+1. (Optional hardening) Create dedicated discussion categories for dispatch/standup/escalation to remove semantic ambiguity.
+2. Map workflow states into Project v2 automation.
 
 Interim replacement workflow (documented):
 - Use issue/discussion fallback protocol in `docs/protocols/discussion-template-usage.md` only if Discussions is later disabled or unavailable.
@@ -76,10 +87,10 @@ Interim replacement workflow (documented):
 - Validator: @matrim-mastermind
 - Samples executed: 4/4 required issue templates
 - Pass count: 4
-- Fail count: 0 (issue templates); 1 pending validation item (discussion live-post verification)
+- Fail count: 0
 - Open follow-ups:
-  - Create and verify GitHub Discussions categories and complete live discussion-post validation.
+  - Optional: create dedicated GitHub Discussions categories for dispatch/standup/escalation.
   - Map workflow states into Project v2 automation.
-- Recommendation: M1 exit **CONDITIONAL GO**
-  - GO for issue-template lifecycle criterion.
-  - Final closeout depends on discussion live-post validation per documented path.
+- Recommendation: M1 exit **GO**
+  - Issue-template lifecycle criterion is satisfied.
+  - Discussion live-post validation is satisfied (3/3 templates posted and linked).


### PR DESCRIPTION
## Done
- Posted one live GitHub Discussion sample for each M1 template path:
  - Dispatch: https://github.com/Vindi-Van/harambee/discussions/64
  - Standup: https://github.com/Vindi-Van/harambee/discussions/65
  - Escalation: https://github.com/Vindi-Van/harambee/discussions/66
- Updated `docs/validation/m1-dry-run-validation-checklist.md` with links, category mapping used, and marked discussion validation complete.
- Updated `docs/task-tracker.md` to mark M1 as Complete.
- Updated `WORKBOARD.md` to reflect M1 closeout and next focus (M2).

## Evidence
- Live discussions posted in repo and publicly reachable at URLs above.
- Validation checklist now shows 3/3 discussion template live-post verification complete and M1 recommendation set to **GO**.
- Commit: `db60174`

## Needs
- Maintainer review/merge.
- Optional follow-up (non-blocking for M1): create dedicated Discussions categories for dispatch/standup/escalation; current mapping uses default categories (General/Show and tell/Q&A).