### PR TITLE
M1: wire Project v2 governance status automation

### DIFF
--- a/.github/workflows/projectv2-governance-sync.yml
+++ b/.github/workflows/projectv2-governance-sync.yml
@@ -1,0 +1,40 @@
+name: Project v2 Governance Sync
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - closed
+
+permissions:
+  contents: read
+  issues: read
+  repository-projects: write
+
+jobs:
+  sync-project-status:
+    runs-on: ubuntu-latest
+    if: ${{ vars.PROJECT_V2_ID != '' && vars.PROJECT_V2_STATUS_FIELD_ID != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync governance labels to Project v2 Status
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_V2_TOKEN != '' && secrets.PROJECT_V2_TOKEN || github.token }}
+          PROJECT_V2_ID: ${{ vars.PROJECT_V2_ID }}
+          PROJECT_V2_STATUS_FIELD_ID: ${{ vars.PROJECT_V2_STATUS_FIELD_ID }}
+          PROJECT_V2_OPT_INTAKE: ${{ vars.PROJECT_V2_OPT_INTAKE }}
+          PROJECT_V2_OPT_DESIGN: ${{ vars.PROJECT_V2_OPT_DESIGN }}
+          PROJECT_V2_OPT_REVIEW_GATE: ${{ vars.PROJECT_V2_OPT_REVIEW_GATE }}
+          PROJECT_V2_OPT_DECOMPOSITION: ${{ vars.PROJECT_V2_OPT_DECOMPOSITION }}
+          PROJECT_V2_OPT_EXECUTION: ${{ vars.PROJECT_V2_OPT_EXECUTION }}
+          PROJECT_V2_OPT_VERIFICATION: ${{ vars.PROJECT_V2_OPT_VERIFICATION }}
+          PROJECT_V2_OPT_DEPLOYMENT: ${{ vars.PROJECT_V2_OPT_DEPLOYMENT }}
+          PROJECT_V2_OPT_DONE: ${{ vars.PROJECT_V2_OPT_DONE }}
+          PROJECT_V2_OPT_BLOCKED: ${{ vars.PROJECT_V2_OPT_BLOCKED }}
+        run: |
+          scripts/projectv2_sync.sh "${{ github.repository }}" "${{ github.event.issue.number }}"

--- a/WORKBOARD.md
+++ b/WORKBOARD.md
@@ -23,13 +23,18 @@
   - Escalation: <https://github.com/Vindi-Van/harambee/discussions/66>
 - Marked M1 discussion validation complete in `docs/validation/m1-dry-run-validation-checklist.md`.
 - Closed M1 tracker status in `docs/task-tracker.md`.
+- Added Project v2 governance automation artifacts:
+  - `.github/workflows/projectv2-governance-sync.yml`
+  - `scripts/projectv2_sync.sh`
+  - `docs/governance/project-v2-automation.md`
+- Updated M1 validation/tracker docs to reflect automation wiring + live validation blocker context.
 
 ## Active (In Progress)
-- M2 dispatch protocol simulation planning (next milestone).
+- Complete live Project v2 validation evidence run (one sample issue through mapped status transitions) after project IDs/options and token scopes are configured.
 
 ## Next
-- Execute M2 dispatch protocol simulation with 3-task anti-collision evidence set.
-- Wire/verify Project v2 workflow automation mappings for documented governance states.
+- Optional hardening: dedicated discussion categories for dispatch/standup/escalation.
+- Begin M3 contracts-in-practice end-to-end flow with QA bounce-back evidence.
 
 ## Blocked
-- None.
+- Project v2 live validation currently blocked by missing `read:project`/`project` token scope and unset repo variables for project/field/option IDs.

--- a/docs/governance/project-v2-automation.md
+++ b/docs/governance/project-v2-automation.md
@@ -1,0 +1,79 @@
+# GitHub Project v2 Automation Mapping
+
+This document wires Harambee governance labels/states into a GitHub Project v2 **Status** field.
+
+## Source of Truth
+
+- Lifecycle/stage labels: `docs/governance/states.md`, `docs/governance/labels.md`
+- Transition gates: `docs/governance/transition-gates.md`
+- Automation implementation:
+  - Workflow: `.github/workflows/projectv2-governance-sync.yml`
+  - Script: `scripts/projectv2_sync.sh`
+
+## Mapping Rules (Label/State -> Project Status)
+
+Precedence order (top wins):
+
+1. Issue closed OR `status:done` -> **Done**
+2. `status:blocked` -> **Blocked**
+3. `stage:deployment` -> **Deployment**
+4. `stage:verification` -> **Verification**
+5. `stage:execution` -> **Execution**
+6. `stage:decomposition` -> **Decomposition**
+7. `stage:review-gate` -> **Review Gate**
+8. `stage:design` -> **Design**
+9. `stage:intake` (or default) -> **Intake**
+
+This aligns with canonical lifecycle and preserves blocked/done overrides.
+
+## Required Repo Variables
+
+Set these repository variables before enabling full automation:
+
+- `PROJECT_V2_ID`
+- `PROJECT_V2_STATUS_FIELD_ID`
+- `PROJECT_V2_OPT_INTAKE`
+- `PROJECT_V2_OPT_DESIGN`
+- `PROJECT_V2_OPT_REVIEW_GATE`
+- `PROJECT_V2_OPT_DECOMPOSITION`
+- `PROJECT_V2_OPT_EXECUTION`
+- `PROJECT_V2_OPT_VERIFICATION`
+- `PROJECT_V2_OPT_DEPLOYMENT`
+- `PROJECT_V2_OPT_DONE`
+- `PROJECT_V2_OPT_BLOCKED`
+
+Optional repository secret:
+
+- `PROJECT_V2_TOKEN` (recommended PAT with `project` + `repo` scopes when project is org/user-scoped and `github.token` lacks access)
+
+## How to Fetch IDs (one-time)
+
+`gh` must be authenticated with `read:project` (and `project` for writes).
+
+```bash
+# List projects for owner
+gh project list --owner <owner>
+
+# Inspect a project (copy project id, field ids, option ids)
+gh project view <number> --owner <owner> --format json
+```
+
+Then copy IDs into repo variables.
+
+## Local Manual Sync Command
+
+```bash
+# Uses current GH_TOKEN + repo variables exported in shell
+authority_repo="Vindi-Van/harambee"
+issue_number="<issue-number>"
+scripts/projectv2_sync.sh "$authority_repo" "$issue_number"
+```
+
+## Validation Protocol (minimum evidence)
+
+1. Create or pick one sample issue.
+2. Add stage/status labels (`stage:intake`, `status:ready`) and trigger workflow.
+3. Confirm issue appears in project with **Intake** status.
+4. Transition labels to `stage:execution`, then `stage:verification`, then close issue.
+5. Confirm project item status transitions: **Execution** -> **Verification** -> **Done**.
+6. Save command/run links in `docs/validation/m1-dry-run-validation-checklist.md`.

--- a/docs/governance/states.md
+++ b/docs/governance/states.md
@@ -25,6 +25,8 @@ Use **Status** as the canonical project field for board columns.
 | Done | `stage:deployment` + `status:done` | Completed with evidence |
 | Blocked | any + `status:blocked` | Delivery blocked pending unblock action |
 
+Automation wiring reference: `docs/governance/project-v2-automation.md`
+
 ## State Rules
 - Exactly one `stage:*` label at a time.
 - Task cannot advance if required artifacts are missing.

--- a/docs/task-tracker.md
+++ b/docs/task-tracker.md
@@ -1,6 +1,6 @@
 # Harambee Task Tracker
 
-_Last updated: 2026-03-02 (M1 closeout validated)_
+_Last updated: 2026-03-02 (Project v2 automation wiring added; live validation blocked on project scope/config)_
 
 This tracker records what is **done** vs **not done** by milestone and execution track.
 
@@ -9,7 +9,7 @@ This tracker records what is **done** vs **not done** by milestone and execution
 | Milestone | Status | Done | Not Done / Remaining |
 | --- | --- | --- | --- |
 | M0 — Foundation Docs | In review | Architecture/docs baseline exists (`docs/architecture-v1.md`, `docs/milestones.md`, `docs/task-breakdown.md`, `docs/roles-and-contracts.md`, `docs/complexity-rubric.md`) | Explicit "human approval of v1 design baseline" not yet recorded in repo artifacts |
-| M1 — Workflow Schema & Governance | Complete | Real dry-run executed: one sample issue each for task/bug/design/blocker (#58-#61), lifecycle transitions captured, validation checklist updated, discussion templates + usage protocol added, repo Discussions enabled (`has_discussions=true`, GraphQL `hasDiscussionsEnabled=true`), and live sample discussions posted for dispatch/standup/escalation (#64-#66) | Optional hardening: dedicated discussion categories; remaining required work is Project v2 automation mapping |
+| M1 — Workflow Schema & Governance | In progress | Real dry-run executed: one sample issue each for task/bug/design/blocker (#58-#61), lifecycle transitions captured, validation checklist updated, discussion templates + usage protocol added, repo Discussions enabled (`has_discussions=true`, GraphQL `hasDiscussionsEnabled=true`), live sample discussions posted for dispatch/standup/escalation (#64-#66), and Project v2 automation workflow/script/docs added | Live project validation still blocked until project IDs/options are configured and a token with `read:project`/`project` scopes is available |
 | M2 — OgaArchitect Dispatch | Not started | Protocol docs exist (`docs/protocols/assignment-flow.md`) | Simulated assignment run evidence for 3 tasks without collision not yet produced |
 | M3 — Contracts in Practice | Not started | Test matrix seeds exist in docs/testing | End-to-end feature flow with QA bounce-back evidence not yet produced |
 | M4 — Optional Redis Coordination | Not started | None required yet | Failure simulation + safe reassignment evidence not yet produced |
@@ -33,8 +33,12 @@ This tracker records what is **done** vs **not done** by milestone and execution
 ### Track B — Workflow Operations / Project Wiring
 - ✅ Done
   - Repo-level governance state/label definitions documented.
+  - Automation implementation added:
+    - `.github/workflows/projectv2-governance-sync.yml`
+    - `scripts/projectv2_sync.sh`
+    - `docs/governance/project-v2-automation.md`
 - ⏳ Not done
-  - GitHub Project v2 automation bindings + enforcement evidence not yet captured in repo.
+  - Live enforcement evidence for at least one issue transition in Project v2 (blocked pending project scope/token + option ID config).
 
 ### Track C — Validation & Exit Evidence (M1 Exit)
 - ✅ Done

--- a/docs/validation/m1-dry-run-validation-checklist.md
+++ b/docs/validation/m1-dry-run-validation-checklist.md
@@ -25,7 +25,9 @@ Discussion-template path addressed in this run:
 
 - [x] Labels in `docs/governance/labels.md` are now available in repo labels.
   - Evidence: labels created via `gh label create` set (all governance families present).
-- [ ] Workflow states in Project v2 are mapped (still pending; out of this run’s scope).
+- [~] Workflow states in Project v2 are mapped via automation artifacts, but live run evidence is pending project scope/config.
+  - Added: `.github/workflows/projectv2-governance-sync.yml`, `scripts/projectv2_sync.sh`, `docs/governance/project-v2-automation.md`
+  - Blocker: current local `gh` token lacks `read:project`/`project` scopes; repo vars for project/field/option IDs are unset.
 - [x] Transition gate requirements from `docs/governance/transition-gates.md` were used as dry-run gate reference.
 
 ---
@@ -74,7 +76,7 @@ Category mapping used for M1 validation:
 
 Follow-up action required:
 1. (Optional hardening) Create dedicated discussion categories for dispatch/standup/escalation to remove semantic ambiguity.
-2. Map workflow states into Project v2 automation.
+2. Complete live Project v2 validation run after setting project IDs/options + token scopes (see `docs/governance/project-v2-automation.md`).
 
 Interim replacement workflow (documented):
 - Use issue/discussion fallback protocol in `docs/protocols/discussion-template-usage.md` only if Discussions is later disabled or unavailable.

--- a/scripts/projectv2_sync.sh
+++ b/scripts/projectv2_sync.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync a GitHub issue's governance labels to a Project v2 Status field.
+#
+# Required env:
+#   PROJECT_V2_ID
+#   PROJECT_V2_STATUS_FIELD_ID
+#   PROJECT_V2_OPT_INTAKE
+#   PROJECT_V2_OPT_DESIGN
+#   PROJECT_V2_OPT_REVIEW_GATE
+#   PROJECT_V2_OPT_DECOMPOSITION
+#   PROJECT_V2_OPT_EXECUTION
+#   PROJECT_V2_OPT_VERIFICATION
+#   PROJECT_V2_OPT_DEPLOYMENT
+#   PROJECT_V2_OPT_DONE
+#   PROJECT_V2_OPT_BLOCKED
+#
+# Usage:
+#   scripts/projectv2_sync.sh <owner/repo> <issue_number>
+
+REPO="${1:-}"
+ISSUE_NUMBER="${2:-}"
+
+if [[ -z "$REPO" || -z "$ISSUE_NUMBER" ]]; then
+  echo "usage: $0 <owner/repo> <issue_number>" >&2
+  exit 2
+fi
+
+required_env=(
+  PROJECT_V2_ID
+  PROJECT_V2_STATUS_FIELD_ID
+  PROJECT_V2_OPT_INTAKE
+  PROJECT_V2_OPT_DESIGN
+  PROJECT_V2_OPT_REVIEW_GATE
+  PROJECT_V2_OPT_DECOMPOSITION
+  PROJECT_V2_OPT_EXECUTION
+  PROJECT_V2_OPT_VERIFICATION
+  PROJECT_V2_OPT_DEPLOYMENT
+  PROJECT_V2_OPT_DONE
+  PROJECT_V2_OPT_BLOCKED
+)
+
+for k in "${required_env[@]}"; do
+  if [[ -z "${!k:-}" ]]; then
+    echo "missing required env: $k" >&2
+    exit 2
+  fi
+done
+
+issue_json="$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}")"
+state="$(jq -r '.state' <<<"$issue_json")"
+labels="$(jq -r '.labels[].name' <<<"$issue_json" || true)"
+
+has_label() {
+  local needle="$1"
+  grep -Fxq "$needle" <<<"$labels"
+}
+
+target_key="intake"
+if [[ "$state" == "closed" ]] || has_label "status:done"; then
+  target_key="done"
+elif has_label "status:blocked"; then
+  target_key="blocked"
+elif has_label "stage:deployment"; then
+  target_key="deployment"
+elif has_label "stage:verification"; then
+  target_key="verification"
+elif has_label "stage:execution"; then
+  target_key="execution"
+elif has_label "stage:decomposition"; then
+  target_key="decomposition"
+elif has_label "stage:review-gate"; then
+  target_key="review_gate"
+elif has_label "stage:design"; then
+  target_key="design"
+elif has_label "stage:intake"; then
+  target_key="intake"
+fi
+
+case "$target_key" in
+  intake) option_id="$PROJECT_V2_OPT_INTAKE" ;;
+  design) option_id="$PROJECT_V2_OPT_DESIGN" ;;
+  review_gate) option_id="$PROJECT_V2_OPT_REVIEW_GATE" ;;
+  decomposition) option_id="$PROJECT_V2_OPT_DECOMPOSITION" ;;
+  execution) option_id="$PROJECT_V2_OPT_EXECUTION" ;;
+  verification) option_id="$PROJECT_V2_OPT_VERIFICATION" ;;
+  deployment) option_id="$PROJECT_V2_OPT_DEPLOYMENT" ;;
+  done) option_id="$PROJECT_V2_OPT_DONE" ;;
+  blocked) option_id="$PROJECT_V2_OPT_BLOCKED" ;;
+  *)
+    echo "unknown target key: $target_key" >&2
+    exit 2
+    ;;
+esac
+
+issue_node_id="$({
+  gh api graphql \
+    -f query='query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { issue(number:$number) { id } } }' \
+    -f owner="${REPO%%/*}" \
+    -f repo="${REPO##*/}" \
+    -F number="$ISSUE_NUMBER"
+} | jq -r '.data.repository.issue.id')"
+
+if [[ -z "$issue_node_id" || "$issue_node_id" == "null" ]]; then
+  echo "failed to resolve issue node id for ${REPO}#${ISSUE_NUMBER}" >&2
+  exit 1
+fi
+
+item_id="$({
+  gh api graphql \
+    -f query='mutation($project:ID!, $content:ID!) { addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } } }' \
+    -f project="$PROJECT_V2_ID" \
+    -f content="$issue_node_id"
+} | jq -r '.data.addProjectV2ItemById.item.id')"
+
+if [[ -z "$item_id" || "$item_id" == "null" ]]; then
+  echo "failed to add/fetch project item for ${REPO}#${ISSUE_NUMBER}" >&2
+  exit 1
+fi
+
+gh api graphql \
+  -f query='mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) { updateProjectV2ItemFieldValue(input:{ projectId:$project, itemId:$item, fieldId:$field, value:{ singleSelectOptionId:$option } }) { projectV2Item { id } } }' \
+  -f project="$PROJECT_V2_ID" \
+  -f item="$item_id" \
+  -f field="$PROJECT_V2_STATUS_FIELD_ID" \
+  -f option="$option_id" >/dev/null
+
+echo "synced ${REPO}#${ISSUE_NUMBER} -> ${target_key} (option ${option_id})"


### PR DESCRIPTION
## Done
- Added Project v2 governance sync workflow:
  - `.github/workflows/projectv2-governance-sync.yml`
- Added executable sync script:
  - `scripts/projectv2_sync.sh`
- Added setup + mapping docs:
  - `docs/governance/project-v2-automation.md`
- Linked governance state doc to automation wiring:
  - `docs/governance/states.md`
- Updated validation/tracking artifacts:
  - `docs/validation/m1-dry-run-validation-checklist.md`
  - `docs/task-tracker.md`
  - `WORKBOARD.md`

## Evidence
- Script syntax check passes:
  - `bash -n scripts/projectv2_sync.sh`
- Mapping precedence codified in script/doc:
  - closed/done override, blocked override, then stage mapping (`intake -> deployment`)
- Automation is guarded by repo vars and writes Project v2 field only when configured.

## Needs
- **BLOCKED for live proof step** (sample issue entering project + verified transitions) due missing access/config:
  1. Local token currently lacks `read:project`/`project` scopes (`gh project list --owner Vindi-Van` fails).
  2. Repository variables for project/field/option IDs are not yet set.
- To unblock and finish final evidence in-repo:
  1. Add required vars (`PROJECT_V2_ID`, `PROJECT_V2_STATUS_FIELD_ID`, `PROJECT_V2_OPT_*`).
  2. Provide PAT secret `PROJECT_V2_TOKEN` (scopes: `repo`, `project`) if `github.token` cannot access project.
  3. Run one sample issue through `stage:intake -> stage:execution -> stage:verification -> closed` and capture Project Status transitions.
