### PR TITLE
docs: add default-branch migration runbook to main

### DIFF
--- a/WORKBOARD.md
+++ b/WORKBOARD.md
@@ -27,6 +27,8 @@
 ## Recently Completed (Optional Backlog)
 - Added periodic replay-check operations runbook for M4 telemetry + M5 external adoption:
   - `docs/validation/m4-m5-periodic-replay-check-runbook.md`
+- Added default-branch canonicalization runbook (`master` -> `main`) with maintainer UI switch + CLI verification:
+  - `docs/validation/default-branch-main-migration-runbook.md`
 
 ## Blocked
 - None.

--- a/docs/task-tracker.md
+++ b/docs/task-tracker.md
@@ -1,6 +1,6 @@
 # Harambee Task Tracker
 
-_Last updated: 2026-03-02 (completed incremental governance-state reporting refinement artifact)_
+_Last updated: 2026-03-02 (added default-branch canonicalization runbook for `main` migration)_
 
 This tracker records what is **done** vs **not done** by milestone and execution track.
 
@@ -42,4 +42,5 @@ This tracker records what is **done** vs **not done** by milestone and execution
 - M4 checklist + telemetry replay: `docs/validation/m4-redis-failure-simulation-checklist.md`, `docs/validation/artifacts/m4-live-redis-telemetry-replay-2026-03-02.md`
 - M5 adoption guide + replay artifact: `docs/starter-kit/adoption-under-1-day.md`, `docs/validation/artifacts/m5-external-adoption-replay-2026-03-02.md`
 - Final status artifact: `docs/validation/project-status-2026-03-02.md`
+- Default-branch migration runbook: `docs/validation/default-branch-main-migration-runbook.md`
 - Current board: `WORKBOARD.md`

--- a/docs/validation/default-branch-main-migration-runbook.md
+++ b/docs/validation/default-branch-main-migration-runbook.md
@@ -1,0 +1,78 @@
+# Default Branch Migration Runbook (`master` -> `main`)
+
+Date: 2026-03-02  
+Status: Ready for maintainers (manual GitHub UI step required)
+
+## Purpose
+Provide a minimal, repeatable runbook for switching a repository default branch to `main` and validating the repository state after the switch.
+
+## Scope
+- Canonical default branch should be `main`.
+- Actual default-branch switch in GitHub is a **maintainer/admin UI action**.
+- This runbook captures both UI and CLI verification steps.
+
+## 1) Pre-checks (CLI)
+Run before touching settings:
+
+```bash
+gh repo view Vindi-Van/harambee --json nameWithOwner,defaultBranchRef --jq '{repo: .nameWithOwner, defaultBranch: .defaultBranchRef.name}'
+git remote show origin
+```
+
+Expected before migration in legacy repos: default branch may still be `master`.
+
+## 2) Local branch canonicalization (if needed)
+If the local branch is still `master`, rename and push:
+
+```bash
+git checkout master
+git branch -m main
+git push -u origin main
+```
+
+If local already uses `main`, skip this step.
+
+## 3) Manual GitHub UI switch (required)
+1. Open repo: `https://github.com/Vindi-Van/harambee`
+2. Go to **Settings** -> **Branches**.
+3. In **Default branch**, click the edit/switch control.
+4. Choose `main`.
+5. Confirm the warning dialog to update default branch.
+
+If branch protection rules target the old branch name, update them to apply to `main`.
+
+## 4) Post-switch verification (CLI)
+Run all checks:
+
+```bash
+# Canonical default branch check
+gh repo view Vindi-Van/harambee --json defaultBranchRef --jq '.defaultBranchRef.name'
+
+# Remote head should point to main
+git remote show origin | sed -n '/HEAD branch/s/.*: //p'
+
+# Ensure main exists remotely
+git ls-remote --heads origin main
+
+# Sanity-check PR base expectation
+gh pr list --repo Vindi-Van/harambee --state open --json number,title,baseRefName --jq '.[] | {number, title, base: .baseRefName}'
+```
+
+Expected:
+- `defaultBranchRef.name` = `main`
+- remote HEAD branch = `main`
+- `refs/heads/main` exists
+- open PRs target `main` unless intentionally overridden
+
+## 5) Optional cleanup
+After confirming no automation depends on `master`:
+
+```bash
+git push origin --delete master
+```
+
+Only do this when maintainers confirm the old branch is no longer required.
+
+## Notes
+- For freshly initialized repos, avoid `master` entirely by starting on `main` from first push.
+- This runbook is the canonical reference for manual default-branch migration in optional hardening follow-ups.

--- a/docs/validation/m5-second-project-adoption-under-1-day-checklist.md
+++ b/docs/validation/m5-second-project-adoption-under-1-day-checklist.md
@@ -91,3 +91,4 @@ M5 can be closed when one dated second-repo run includes:
 
 ## Linked Artifact Template
 - `docs/validation/artifacts/m5-second-project-adoption-simulation-2026-03-02.md`
+- `docs/validation/default-branch-main-migration-runbook.md` (use when canonicalizing `master` -> `main`)


### PR DESCRIPTION
## Summary
- add a minimal runbook for canonical default-branch migration from `master` to `main`
- document the required manual GitHub UI default-branch switch steps
- include post-switch CLI verification commands
- update `WORKBOARD.md` and `docs/task-tracker.md` references

## Why
Follow-up optional hardening: keep branch naming canonical and make maintainer-only UI actions reproducible.

## Testing
- docs-only change; no runtime code changes
