### PR TITLE
chore(m1): refine governance-state sync reporting observability

### DIFF
--- a/WORKBOARD.md
+++ b/WORKBOARD.md
@@ -25,6 +25,8 @@
 - Optional incremental governance-state reporting refinements (future additions).
 
 ## Recently Completed (Optional Backlog)
+- Added additive governance-state reporting observability fields (`issue_state`, `selection_reason`) to `sync_report`, with validation note:
+  - `docs/validation/artifacts/m1-governance-reporting-refinement-2026-03-03.md`
 - Added periodic replay-check operations runbook for M4 telemetry + M5 external adoption:
   - `docs/validation/m4-m5-periodic-replay-check-runbook.md`
 - Added default-branch canonicalization runbook (`master` -> `main`) with maintainer UI switch + CLI verification:

--- a/docs/governance/project-v2-automation.md
+++ b/docs/governance/project-v2-automation.md
@@ -169,11 +169,13 @@ scripts/projectv2_sync.sh "$authority_repo" "$issue_number"
 `projectv2_sync.sh` now emits a single parseable summary line on success:
 
 ```text
-sync_report repo=<owner/repo> issue=<n> governance_key=<intake|...|done|blocked> status_field_id=<field-id> status_option_id=<option-id> gov_field_updated=<true|false> gov_field_id=<field-id|unset> gov_option_id=<option-id|unset>
+sync_report repo=<owner/repo> issue=<n> issue_state=<open|closed> governance_key=<intake|...|done|blocked> selection_reason=<state:closed|label:...|default:intake> status_field_id=<field-id> status_option_id=<option-id> gov_field_updated=<true|false> gov_field_id=<field-id|unset> gov_option_id=<option-id|unset>
 ```
 
 Field semantics:
+- `issue_state`: raw GitHub issue state read by the sync (`open`/`closed`).
 - `governance_key`: canonical lifecycle key selected from labels/state precedence.
+- `selection_reason`: winning precedence rule used to derive `governance_key` (state-driven, label-driven, or default).
 - `status_field_id` + `status_option_id`: coarse built-in `Status` update target.
 - `gov_field_updated`: whether full-granularity `Governance State` was actually written.
 - `gov_field_id` + `gov_option_id`: governance-field target IDs when configured (otherwise `unset`).

--- a/docs/task-tracker.md
+++ b/docs/task-tracker.md
@@ -1,6 +1,6 @@
 # Harambee Task Tracker
 
-_Last updated: 2026-03-02 (added default-branch canonicalization runbook for `main` migration)_
+_Last updated: 2026-03-03 (completed additive governance-state sync-report observability refinement)_
 
 This tracker records what is **done** vs **not done** by milestone and execution track.
 
@@ -9,7 +9,7 @@ This tracker records what is **done** vs **not done** by milestone and execution
 | Milestone | Status | Done | Not Done / Remaining |
 | --- | --- | --- | --- |
 | M0 — Foundation Docs | In review | Architecture/docs baseline exists (`docs/architecture-v1.md`, `docs/milestones.md`, `docs/task-breakdown.md`, `docs/roles-and-contracts.md`, `docs/complexity-rubric.md`) | Explicit "human approval of v1 design baseline" not yet recorded in repo artifacts |
-| M1 — Workflow Schema & Governance | Complete | Dry-run issues, discussion workflows, Project v2 automation + live validation, governance-state hardening, and reporting refinement completed with artifacts | Dedicated category creation remains manual UI-only (fallback mapping enforced) |
+| M1 — Workflow Schema & Governance | Complete | Dry-run issues, discussion workflows, Project v2 automation + live validation, governance-state hardening, and reporting refinements (including `issue_state` + `selection_reason` in `sync_report`) completed with artifacts | Dedicated category creation remains manual UI-only (fallback mapping enforced) |
 | M2 — OgaArchitect Dispatch | Complete | Protocol docs + executable simulation evidence completed (worker-ready/request-task, ack timeout requeue, fix-window enforcement, anti-collision proof) | Optional live-fire replay only |
 | M3 — Contracts in Practice | Complete | Sample flow + QA bounce-back evidence and live replay artifact completed | None blocking |
 | M4 — Optional Redis Coordination | Complete | Protocol + executable failure-mode simulation + telemetry replay artifacts completed | None blocking |
@@ -36,7 +36,8 @@ This tracker records what is **done** vs **not done** by milestone and execution
 - M1 live Project v2 validation: `docs/validation/artifacts/m1-projectv2-live-validation-2026-03-02.txt`
 - M1 governance-state hardening: `docs/validation/artifacts/m1-projectv2-governance-state-hardening-2026-03-02.md`
 - M1 discussion category fallback/API blocker: `docs/validation/artifacts/m1-discussion-category-hardening-2026-03-02.md`
-- M1 reporting refinement: `docs/validation/artifacts/m1-governance-reporting-refinement-2026-03-02.md`
+- M1 reporting refinement (baseline): `docs/validation/artifacts/m1-governance-reporting-refinement-2026-03-02.md`
+- M1 reporting refinement (additive observability): `docs/validation/artifacts/m1-governance-reporting-refinement-2026-03-03.md`
 - M2 checklist: `docs/validation/m2-dispatch-simulation-checklist.md`
 - M3 checklist + live replay: `docs/validation/m3-contracts-in-practice-sample-flow.md`, `docs/validation/artifacts/m3-live-github-replay-2026-03-02.md`
 - M4 checklist + telemetry replay: `docs/validation/m4-redis-failure-simulation-checklist.md`, `docs/validation/artifacts/m4-live-redis-telemetry-replay-2026-03-02.md`

--- a/docs/validation/artifacts/m1-governance-reporting-refinement-2026-03-03.md
+++ b/docs/validation/artifacts/m1-governance-reporting-refinement-2026-03-03.md
@@ -1,0 +1,32 @@
+# M1 Governance Reporting Refinement (2026-03-03)
+
+## Change
+Added two additive fields to `sync_report` emitted by `scripts/projectv2_sync.sh`:
+
+- `issue_state` (`open|closed`) — raw GitHub issue state observed during sync.
+- `selection_reason` — the exact precedence rule that won when deriving `governance_key`.
+
+This is a no-behavior-change reporting refinement: project field writes are unchanged.
+
+## Why
+When `governance_key=done` is emitted, operators can now distinguish whether it came from:
+
+- issue closure (`selection_reason=state:closed`),
+- an explicit label (`selection_reason=label:status:done`), or
+- default fallback (`selection_reason=default:intake` for intake path).
+
+That reduces ambiguity during triage/replay without increasing automation complexity.
+
+## Validation Notes
+
+- Syntax check passed:
+  - `bash -n scripts/projectv2_sync.sh`
+- Output contract check passed:
+  - `grep -n "issue_state=\${state}" scripts/projectv2_sync.sh`
+  - `grep -n "selection_reason=\${selection_reason}" scripts/projectv2_sync.sh`
+
+## Expected `sync_report` shape
+
+```text
+sync_report repo=<owner/repo> issue=<n> issue_state=<open|closed> governance_key=<intake|...|done|blocked> selection_reason=<state:closed|label:...|default:intake> status_field_id=<field-id> status_option_id=<option-id> gov_field_updated=<true|false> gov_field_id=<field-id|unset> gov_option_id=<option-id|unset>
+```

--- a/scripts/projectv2_sync.sh
+++ b/scripts/projectv2_sync.sh
@@ -70,24 +70,37 @@ has_label() {
 }
 
 target_key="intake"
-if [[ "$state" == "closed" ]] || has_label "status:done"; then
+selection_reason="default:intake"
+if [[ "$state" == "closed" ]]; then
   target_key="done"
+  selection_reason="state:closed"
+elif has_label "status:done"; then
+  target_key="done"
+  selection_reason="label:status:done"
 elif has_label "status:blocked"; then
   target_key="blocked"
+  selection_reason="label:status:blocked"
 elif has_label "stage:deployment"; then
   target_key="deployment"
+  selection_reason="label:stage:deployment"
 elif has_label "stage:verification"; then
   target_key="verification"
+  selection_reason="label:stage:verification"
 elif has_label "stage:execution"; then
   target_key="execution"
+  selection_reason="label:stage:execution"
 elif has_label "stage:decomposition"; then
   target_key="decomposition"
+  selection_reason="label:stage:decomposition"
 elif has_label "stage:review-gate"; then
   target_key="review_gate"
+  selection_reason="label:stage:review-gate"
 elif has_label "stage:design"; then
   target_key="design"
+  selection_reason="label:stage:design"
 elif has_label "stage:intake"; then
   target_key="intake"
+  selection_reason="label:stage:intake"
 fi
 
 case "$target_key" in
@@ -170,4 +183,4 @@ if [[ -n "${PROJECT_V2_GOV_FIELD_ID:-}" ]]; then
   fi
 fi
 
-echo "sync_report repo=${REPO} issue=${ISSUE_NUMBER} governance_key=${target_key} status_field_id=${PROJECT_V2_STATUS_FIELD_ID} status_option_id=${status_option_id} gov_field_updated=${gov_field_updated} gov_field_id=${PROJECT_V2_GOV_FIELD_ID:-unset} gov_option_id=${gov_option_id:-unset}"
+echo "sync_report repo=${REPO} issue=${ISSUE_NUMBER} issue_state=${state} governance_key=${target_key} selection_reason=${selection_reason} status_field_id=${PROJECT_V2_STATUS_FIELD_ID} status_option_id=${status_option_id} gov_field_updated=${gov_field_updated} gov_field_id=${PROJECT_V2_GOV_FIELD_ID:-unset} gov_option_id=${gov_option_id:-unset}"


### PR DESCRIPTION
## Summary
- add two additive observability fields to `sync_report` in `scripts/projectv2_sync.sh`:
  - `issue_state`
  - `selection_reason`
- document the expanded report contract in `docs/governance/project-v2-automation.md`
- add a validation note artifact for this incremental refinement
- update `docs/task-tracker.md` and `WORKBOARD.md` to mark this optional item complete

## Why
This keeps automation behavior unchanged while making governance-state derivation easier to audit during triage/replay.

## Validation
- `bash -n scripts/projectv2_sync.sh`
- `grep -n "issue_state=\${state}" scripts/projectv2_sync.sh`
- `grep -n "selection_reason=\${selection_reason}" scripts/projectv2_sync.sh`

## Scope
Tiny docs/script hardening only; no workflow trigger or field-mapping behavior changes.